### PR TITLE
Add a public method to access visual assets.

### DIFF
--- a/BraintreeDropIn.xcodeproj/project.pbxproj
+++ b/BraintreeDropIn.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		03AE59581DDE7E8C000B594C /* BTUIKVisualAssetType.h in Headers */ = {isa = PBXBuildFile; fileRef = 03AE59571DDE7E8C000B594C /* BTUIKVisualAssetType.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		03B793AD1DAD61B500F54B1B /* BTDropInResultTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 03B793AC1DAD61B500F54B1B /* BTDropInResultTests.m */; };
 		03FFF6B01DB82E9D004A1F9B /* BTUI.strings in Resources */ = {isa = PBXBuildFile; fileRef = A52900E81D8903A600032220 /* BTUI.strings */; };
 		A50ED7A61D8AF8C400A78EF0 /* BTPaymentSelectionViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A50ED7A51D8AF8C400A78EF0 /* BTPaymentSelectionViewControllerTests.m */; };
@@ -238,6 +239,7 @@
 		030D98331DC935B200161899 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/BTUI.strings"; sourceTree = "<group>"; };
 		030D98351DC9363500161899 /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/BTUI.strings; sourceTree = "<group>"; };
 		030D98361DC9385300161899 /* zh-Hant-HK */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant-HK"; path = "zh-Hant-HK.lproj/BTUI.strings"; sourceTree = "<group>"; };
+		03AE59571DDE7E8C000B594C /* BTUIKVisualAssetType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BTUIKVisualAssetType.h; sourceTree = "<group>"; };
 		03B793AC1DAD61B500F54B1B /* BTDropInResultTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BTDropInResultTests.m; sourceTree = "<group>"; };
 		1741E0093A0037D2EBE80FE4 /* Pods-Tests-UnitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-UnitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests.release.xcconfig"; sourceTree = "<group>"; };
 		273802B93A7925EB38CBFA75 /* Pods-DropInDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DropInDemo.debug.xcconfig"; path = "Pods/Target Support Files/Pods-DropInDemo/Pods-DropInDemo.debug.xcconfig"; sourceTree = "<group>"; };
@@ -615,6 +617,7 @@
 				A52901111D8903A600032220 /* BTUIKMobileNumberFormField.h */,
 				A52901121D8903A600032220 /* BTUIKPaymentOptionCardView.h */,
 				A52901131D8903A600032220 /* BTUIKPaymentOptionType.h */,
+				03AE59571DDE7E8C000B594C /* BTUIKVisualAssetType.h */,
 				A52901141D8903A600032220 /* BTUIKPostalCodeFormField.h */,
 				A52901151D8903A600032220 /* BTUIKSecurityCodeFormField.h */,
 				A52901161D8903A600032220 /* BTUIKTextField.h */,
@@ -963,6 +966,7 @@
 				A52901A31D8903A600032220 /* BTUIKPaymentOptionType.h in Headers */,
 				A52901A91D8903A700032220 /* BTUIKViewUtil.h in Headers */,
 				A52901EC1D8903A700032220 /* BTUIKLargeApplePayMarkVectorArtView.h in Headers */,
+				03AE59581DDE7E8C000B594C /* BTUIKVisualAssetType.h in Headers */,
 				A52901B11D8903A700032220 /* BTUIKCardVectorArtView.h in Headers */,
 				A52902011D8903A700032220 /* BTUIKLargePayPalMonogramCardView.h in Headers */,
 				A52901F21D8903A700032220 /* BTUIKLargeDinersClubVectorArtView.h in Headers */,

--- a/BraintreeUIKit/Helpers/BTUIKViewUtil.m
+++ b/BraintreeUIKit/Helpers/BTUIKViewUtil.m
@@ -27,6 +27,9 @@
 #import "BTUIKLargeUnionPayVectorArtView.h"
 #import "BTUIKLargeApplePayMarkVectorArtView.h"
 
+#import "BTUIKCVVBackVectorArtView.h"
+#import "BTUIKCVVFrontVectorArtView.h"
+
 @import AudioToolbox;
 
 @implementation BTUIKViewUtil
@@ -203,6 +206,17 @@
         case BTUIKPaymentOptionTypeSwitch:
         case BTUIKPaymentOptionTypeUnknown:
             return size == BTUIKVectorArtSizeRegular ? [BTUIKUnknownCardVectorArtView new] : [BTUIKLargeUnknownCardVectorArtView new];
+    }
+}
+
++ (BTUIKVectorArtView *)vectorArtViewForVisualAssetType:(BTUIKVisualAssetType)type {
+    switch (type) {
+        case BTUIKVisualAssetTypeCVVFront:
+            return [BTUIKCVVFrontVectorArtView new];
+        case BTUIKVisualAssetTypeCVVBack:
+            return [BTUIKCVVBackVectorArtView new];
+        case BTUIKVisualAssetTypeUnknown:
+            return [BTUIKVectorArtView new];
     }
 }
 

--- a/BraintreeUIKit/Public/BTUIKViewUtil.h
+++ b/BraintreeUIKit/Public/BTUIKViewUtil.h
@@ -1,6 +1,7 @@
 #import <UIKit/UIKit.h>
 #import "BTUIKCardType.h"
 #import "BTUIKPaymentOptionType.h"
+#import "BTUIKVisualAssetType.h"
 
 @class BTUIKVectorArtView;
 
@@ -66,6 +67,14 @@ typedef NS_ENUM(NSInteger, BTUIKVectorArtSize) {
 /// @param size The BTUIKVectorArtSize (Regular or Large)
 /// @return The BTUIKVectorArtView for the BTUIKPaymentOptionType if one can be found. Otherwise the art for a generic card.
 + (BTUIKVectorArtView *)vectorArtViewForPaymentOptionType:(BTUIKPaymentOptionType)type size:(BTUIKVectorArtSize)size;
+
+/*!
+ @brief Get a BTUIKVectorArtView for a visual asset.
+
+ @param type A BTUIKVisualAssetType
+ @return The BTUIKVectorArtView for the BTUIKVisualAssetType if one can be found. Otherwise an empty BTUIKVectorArtView.
+*/
++ (BTUIKVectorArtView *)vectorArtViewForVisualAssetType:(BTUIKVisualAssetType)type;
 
 #pragma mark Right to Left Utilities
 

--- a/BraintreeUIKit/Public/BTUIKVisualAssetType.h
+++ b/BraintreeUIKit/Public/BTUIKVisualAssetType.h
@@ -1,0 +1,8 @@
+/*!
+ @brief Visual assets
+*/
+typedef NS_ENUM(NSInteger, BTUIKVisualAssetType) {
+    BTUIKVisualAssetTypeUnknown = 0,
+    BTUIKVisualAssetTypeCVVBack,
+    BTUIKVisualAssetTypeCVVFront,
+};

--- a/BraintreeUIKit/Public/BraintreeUIKit.h
+++ b/BraintreeUIKit/Public/BraintreeUIKit.h
@@ -28,3 +28,4 @@ FOUNDATION_EXPORT const unsigned char BraintreeUIKitVersionString[];
 #import "BTUIKLocalizedString.h"
 #import "BTUIKCardExpirationValidator.h"
 #import "BTUIKCardExpiryFormat.h"
+#import "BTUIKVisualAssetType.h"

--- a/UnitTests/BTUIKViewUtilTests.m
+++ b/UnitTests/BTUIKViewUtilTests.m
@@ -2,6 +2,9 @@
 
 #import "BTUIKViewUtil.h"
 #import "BTUIKPaymentOptionType.h"
+#import "BTUIKVisualAssetType.h"
+#import "BTUIKCVVBackVectorArtView.h"
+#import "BTUIKCVVFrontVectorArtView.h"
 
 @interface BTUIKViewUtilTests : XCTestCase
 
@@ -51,4 +54,28 @@
         XCTAssertFalse([BTUIKViewUtil isPaymentOptionTypeACreditCard:[notACreditCard integerValue]], @"Payment Option Type with integer value %@", notACreditCard);
     }
 }
+
+- (void)test_getsAssetForAllVisualAssetTypes {
+    NSArray *visualAssetTypes = @[
+                                                 @(BTUIKVisualAssetTypeUnknown),
+                                                 @(BTUIKVisualAssetTypeCVVBack),
+                                                 @(BTUIKVisualAssetTypeCVVFront),
+                                                 ];
+    for (NSNumber *visualAsset in visualAssetTypes) {
+        BTUIKVectorArtView *testAsset = [BTUIKViewUtil vectorArtViewForVisualAssetType:[visualAsset integerValue]];
+        XCTAssertNotNil(testAsset);
+        switch ([visualAsset integerValue]) {
+            case 1:
+                XCTAssertTrue([testAsset isKindOfClass:[BTUIKCVVBackVectorArtView class]]);
+                break;
+            case 2:
+                XCTAssertTrue([testAsset isKindOfClass:[BTUIKCVVFrontVectorArtView class]]);
+                break;
+            default:
+                XCTAssertTrue([testAsset isKindOfClass:[BTUIKVectorArtView class]]);
+                break;
+        }
+    }
+}
+
 @end


### PR DESCRIPTION
See https://github.com/braintree/braintree_ios/issues/289

Rather than exposing the headers - I've opted to follow our existing pattern where assets are fetched via `BTUIKViewUtils`.