### PR TITLE
Rename insertIntoLozalizedString to insertIntoLocalizedString.

### DIFF
--- a/BraintreeDropIn/Custom Views/BTEnrollmentVerificationViewController.m
+++ b/BraintreeDropIn/Custom Views/BTEnrollmentVerificationViewController.m
@@ -49,7 +49,7 @@
     self.smsSentLabel.translatesAutoresizingMaskIntoConstraints = NO;
     self.smsSentLabel.textAlignment = NSTextAlignmentCenter;
     NSString *fullMobileNumber = [NSString stringWithFormat:@"+%@ %@", self.mobileCountryCode, self.mobilePhoneNumber];
-    self.smsSentLabel.text = [BTUIKLocalizedString insertIntoLozalizedString:BTUIKLocalizedString(ENTER_SMS_CODE_SENT_HELP_LABEL) replacement:fullMobileNumber];
+    self.smsSentLabel.text = [BTUIKLocalizedString insertIntoLocalizedString:BTUIKLocalizedString(ENTER_SMS_CODE_SENT_HELP_LABEL) replacement:fullMobileNumber];
     self.smsSentLabel.numberOfLines = 0;
     [self.view addSubview:self.smsSentLabel];
     [BTUIKAppearance styleLargeLabelSecondary:self.smsSentLabel];

--- a/BraintreeUIKit/Localization/BTUIKLocalizedString.m
+++ b/BraintreeUIKit/Localization/BTUIKLocalizedString.m
@@ -19,11 +19,11 @@
 
 #pragma mark Localization helpers
 
-+ (NSString *)insertIntoLozalizedString:(NSString *)string replacement:(NSString* )replacement {
-    return [self insertIntoLozalizedString:string replacement:replacement token:@"%s"];
++ (NSString *)insertIntoLocalizedString:(NSString *)string replacement:(NSString* )replacement {
+    return [self insertIntoLocalizedString:string replacement:replacement token:@"%s"];
 }
 
-+ (NSString *)insertIntoLozalizedString:(NSString *)string replacement:(NSString* )replacement token:(NSString *)token {
++ (NSString *)insertIntoLocalizedString:(NSString *)string replacement:(NSString* )replacement token:(NSString *)token {
     return [string stringByReplacingOccurrencesOfString:token withString:replacement];
 }
 

--- a/BraintreeUIKit/Public/BTUIKLocalizedString.h
+++ b/BraintreeUIKit/Public/BTUIKLocalizedString.h
@@ -6,9 +6,9 @@
 
 #pragma mark Localization helpers
 
-+ (NSString *)insertIntoLozalizedString:(NSString *)string replacement:(NSString* )replacement;
++ (NSString *)insertIntoLocalizedString:(NSString *)string replacement:(NSString* )replacement;
 
-+ (NSString *)insertIntoLozalizedString:(NSString *)string replacement:(NSString* )replacement token:(NSString *)token;
++ (NSString *)insertIntoLocalizedString:(NSString *)string replacement:(NSString* )replacement token:(NSString *)token;
 
 #pragma mark Localizations
 


### PR DESCRIPTION
See https://github.com/braintree/braintree-ios-drop-in/issues/8

This is a breaking change - but considering the undocumented/recent introduction of the typo and the fact that we are still marking the SDK as `beta` - I think we can treat this as a bug.