### PR TITLE
Include of non-modular header inside framework module error in BTPaymentSelectionViewController

### DIFF
--- a/BraintreeDropIn/BTPaymentSelectionViewController.m
+++ b/BraintreeDropIn/BTPaymentSelectionViewController.m
@@ -16,6 +16,14 @@
 #import <BraintreeCard/BraintreeCard.h>
 #endif
 
+#if __has_include("BraintreeApplePay.h")
+#define __BT_APPLE_PAY
+#import "BraintreeApplePay.h"
+#elif __has_include(<BraintreeApplePay/BraintreeApplePay.h>)
+#define __BT_APPLE_PAY
+#import <BraintreeApplePay/BraintreeApplePay.h>
+#endif
+
 #define SAVED_PAYMENT_METHODS_COLLECTION_SPACING 6
 #define SAVED_PAYMENT_METHODS_COLLECTION_WIDTH 105
 #define SAVED_PAYMENT_METHODS_COLLECTION_HEIGHT 165

--- a/BraintreeDropIn/Public/BTPaymentSelectionViewController.h
+++ b/BraintreeDropIn/Public/BTPaymentSelectionViewController.h
@@ -6,14 +6,6 @@
 #import <BraintreeUIKit/BraintreeUIKit.h>
 #endif
 
-#if __has_include("BraintreeApplePay.h")
-#define __BT_APPLE_PAY 
-#import "BraintreeApplePay.h"
-#elif __has_include(<BraintreeApplePay/BraintreeApplePay.h>)
-#define __BT_APPLE_PAY
-#import <BraintreeApplePay/BraintreeApplePay.h>
-#endif
-
 @class BTPaymentMethodNonce;
 
 @protocol BTPaymentSelectionViewControllerDelegate;

--- a/UnitTests/BTPaymentSelectionViewControllerTests.m
+++ b/UnitTests/BTPaymentSelectionViewControllerTests.m
@@ -1,6 +1,7 @@
 #import <XCTest/XCTest.h>
 
 #import "BTPaymentSelectionViewController.h"
+#import "BTConfiguration.h"
 
 @interface BTPaymentSelectionViewController ()
 @property (nonatomic, strong) NSArray *paymentOptionsData;


### PR DESCRIPTION
This fixes an issue I was occasionally seeing when trying to add in the DropIn UI and Braintree/ApplePay into my project using Cocoapods. 