### PR TITLE
Use a different sheet height if there are no existing payment methods

### DIFF
--- a/BraintreeDropIn/BTDropInController.m
+++ b/BraintreeDropIn/BTDropInController.m
@@ -18,7 +18,6 @@
 
 #define BT_ANIMATION_SLIDE_SPEED 0.35
 #define BT_ANIMATION_TRANSITION_SPEED 0.1
-#define BT_HALF_SHEET_HEIGHT 470
 #define BT_HALF_SHEET_MARGIN 5
 #define BT_HALF_SHEET_CORNER_RADIUS 12
 
@@ -327,7 +326,7 @@
         // Flexible views
         int statusBarHeight = [UIApplication sharedApplication].statusBarFrame.size.height;
         int sh = [[UIScreen mainScreen] bounds].size.height;
-        int sheetHeight = BT_HALF_SHEET_HEIGHT;
+        int sheetHeight = [self.paymentSelectionViewController sheetHeight];
         self.contentHeightConstraint.constant = self.isFullScreen ? statusBarHeight + [self sheetInset] : (sh - sheetHeight - [self sheetInset]);
     }
     
@@ -463,6 +462,24 @@
             self.handler(self, result, error);
         }
     }
+}
+
+- (void) sheetHeightDidChange:(__unused BTPaymentSelectionViewController *)sender {
+    if ([self isFormSheet]) {
+        // iPad formSheet
+        self.contentHeightConstraint.constant = 0;
+    } else {
+        // Flexible views
+        int statusBarHeight = [UIApplication sharedApplication].statusBarFrame.size.height;
+        int sh = [[UIScreen mainScreen] bounds].size.height;
+        int sheetHeight = [self.paymentSelectionViewController sheetHeight];
+        self.contentHeightConstraint.constant = self.isFullScreen ? statusBarHeight + [self sheetInset] : (sh - sheetHeight - [self sheetInset]);
+    }
+    self.contentHeightConstraintBottom.constant = -[self sheetInset];
+
+    [UIView animateWithDuration:BT_ANIMATION_TRANSITION_SPEED delay:0.0 usingSpringWithDamping:0.8 initialSpringVelocity:4 options:0 animations:^{
+        [self.view layoutIfNeeded];
+    } completion:nil];
 }
 
 @end

--- a/BraintreeDropIn/BTPaymentSelectionViewController.m
+++ b/BraintreeDropIn/BTPaymentSelectionViewController.m
@@ -232,6 +232,10 @@
             }
             [self showLoadingScreen:NO animated:YES];
             self.stackView.hidden = NO;
+            [self.view layoutIfNeeded];
+            if (self.delegate) {
+                [self.delegate sheetHeightDidChange:self];
+            }
         }];
     }
 }
@@ -301,6 +305,10 @@
     heightConstraint.priority = UILayoutPriorityDefaultHigh;
     heightConstraint.active = true;
     return spacer;
+}
+
+- (float) sheetHeight {
+    return self.paymentMethodNonces.count == 0 ? 280 : 470;
 }
 
 #pragma mark - Protocol conformance

--- a/BraintreeDropIn/Public/BTPaymentSelectionViewController.h
+++ b/BraintreeDropIn/Public/BTPaymentSelectionViewController.h
@@ -20,6 +20,9 @@
 /// The delegate
 @property (nonatomic, weak) id<BTPaymentSelectionViewControllerDelegate> delegate;
 
+/// The desired height when rendering the view in a sheet.
+- (float)sheetHeight;
+
 @end
 
 @protocol BTPaymentSelectionViewControllerDelegate <NSObject>
@@ -30,6 +33,11 @@
 /// @param nonce The BTPaymentMethodNonce of the selected payment method. @note This can be `nil` in the case of Apple Pay.
 /// @param error The error that occured during tokenization of a new payment method.
 - (void) selectionCompletedWithPaymentMethodType:(BTUIKPaymentOptionType) type nonce:(BTPaymentMethodNonce *)nonce error:(NSError *)error;
+
+/// Called on the delegate when the value return by BTPaymentSelectionViewController:sheetHeight has changed
+///
+/// @param sender The BTPaymentSelectionViewController that changed
+- (void) sheetHeightDidChange:(BTPaymentSelectionViewController *) sender;
 
 @end
 


### PR DESCRIPTION
Currently, there is a lot of empty space in the `half sheet` if there are no existing payment methods. This PR adds the ability to adjust the sheet height and update it from the BTPaymentSelectionViewController.

<img width="313" alt="short" src="https://cloud.githubusercontent.com/assets/7817434/21701016/2fd07e5e-d358-11e6-9727-500e9aa1dc23.png">
<img width="311" alt="tall" src="https://cloud.githubusercontent.com/assets/7817434/21701015/2fcf004c-d358-11e6-9ad4-7ecaeedafef5.png">

