### PR TITLE
Remove beta message

### DIFF
--- a/BraintreeDropIn/Public/BTDropInController.h
+++ b/BraintreeDropIn/Public/BTDropInController.h
@@ -1,5 +1,3 @@
-#pragma message "⚠️ BraintreeDropIn is currently in beta and may change."
-
 #import <UIKit/UIKit.h>
 #import "BTDropInBaseViewController.h"
 #import "BTDropInResult.h"


### PR DESCRIPTION
It is time to remove the beta message which purposely resulted in warnings when building.