### PR TITLE
Add a check to determine whether the customer added a new card or used a vaulted card

### DIFF
--- a/BraintreeDropIn/BTDropInController.m
+++ b/BraintreeDropIn/BTDropInController.m
@@ -452,14 +452,14 @@
     [viewController dismissViewControllerAnimated:YES completion:nil];
 }
 
-- (void)selectionCompletedWithPaymentMethodType:(BTUIKPaymentOptionType)type nonce:(BTPaymentMethodNonce *)nonce isRecentItem:(BOOL)recentItem error:(NSError *)error {
+- (void)selectionCompletedWithPaymentMethodType:(BTUIKPaymentOptionType)type nonce:(BTPaymentMethodNonce *)nonce isVaultedItem:(BOOL)vaultedItem error:(NSError *)error {
     if (error == nil) {
         [[NSUserDefaults standardUserDefaults] setInteger:type forKey:@"BT_dropInLastSelectedPaymentMethodType"];
         if (self.handler != nil) {
             BTDropInResult *result = [BTDropInResult new];
             result.paymentOptionType = type;
             result.paymentMethod = nonce;
-            result.recentItem = recentItem;
+            result.vaultedItem = vaultedItem;
             self.handler(self, result, error);
         }
     }

--- a/BraintreeDropIn/BTDropInController.m
+++ b/BraintreeDropIn/BTDropInController.m
@@ -452,13 +452,14 @@
     [viewController dismissViewControllerAnimated:YES completion:nil];
 }
 
-- (void)selectionCompletedWithPaymentMethodType:(BTUIKPaymentOptionType)type nonce:(BTPaymentMethodNonce *)nonce error:(NSError *)error {
+- (void)selectionCompletedWithPaymentMethodType:(BTUIKPaymentOptionType)type nonce:(BTPaymentMethodNonce *)nonce isRecentItem:(BOOL)recentItem error:(NSError *)error {
     if (error == nil) {
         [[NSUserDefaults standardUserDefaults] setInteger:type forKey:@"BT_dropInLastSelectedPaymentMethodType"];
         if (self.handler != nil) {
             BTDropInResult *result = [BTDropInResult new];
             result.paymentOptionType = type;
             result.paymentMethod = nonce;
+            result.recentItem = recentItem;
             self.handler(self, result, error);
         }
     }

--- a/BraintreeDropIn/BTPaymentSelectionViewController.m
+++ b/BraintreeDropIn/BTPaymentSelectionViewController.m
@@ -367,7 +367,7 @@
 - (void)collectionView:(__unused UICollectionView *)savedPaymentMethodsCollectionView didSelectItemAtIndexPath:(__unused NSIndexPath *)indexPath {
     BTUIPaymentMethodCollectionViewCell *cell = (BTUIPaymentMethodCollectionViewCell*)[savedPaymentMethodsCollectionView cellForItemAtIndexPath:indexPath];
     if (self.delegate) {
-        [self.delegate selectionCompletedWithPaymentMethodType:[BTUIKViewUtil paymentOptionTypeForPaymentInfoType:cell.paymentMethodNonce.type] nonce:cell.paymentMethodNonce error:nil];
+        [self.delegate selectionCompletedWithPaymentMethodType:[BTUIKViewUtil paymentOptionTypeForPaymentInfoType:cell.paymentMethodNonce.type] nonce:cell.paymentMethodNonce isRecentItem:true error:nil];
     }
 }
 
@@ -415,7 +415,7 @@
         [[BTTokenizationService sharedService] tokenizeType:@"PayPal" options:options withAPIClient:self.apiClient completion:^(BTPaymentMethodNonce * _Nullable paymentMethodNonce, NSError * _Nullable error) {
             if (self.delegate && paymentMethodNonce != nil) {
                 BTUIKPaymentOptionType type = [BTUIKViewUtil paymentOptionTypeForPaymentInfoType:paymentMethodNonce.type];
-                [self.delegate selectionCompletedWithPaymentMethodType:type nonce:paymentMethodNonce error:error];
+                [self.delegate selectionCompletedWithPaymentMethodType:type nonce:paymentMethodNonce isRecentItem:false error:error];
             }
         }];
         
@@ -426,12 +426,12 @@
         }
         [[BTTokenizationService sharedService] tokenizeType:@"Venmo" options:options withAPIClient:self.apiClient completion:^(BTPaymentMethodNonce * _Nullable paymentMethodNonce, NSError * _Nullable error) {
             if (self.delegate && paymentMethodNonce != nil) {
-                [self.delegate selectionCompletedWithPaymentMethodType:BTUIKPaymentOptionTypeVenmo nonce:paymentMethodNonce error:error];
+                [self.delegate selectionCompletedWithPaymentMethodType:BTUIKPaymentOptionTypeVenmo nonce:paymentMethodNonce isRecentItem:false error:error];
             }
         }];
     } else if(cell.type == BTUIKPaymentOptionTypeApplePay) {
         if (self.delegate) {
-            [self.delegate selectionCompletedWithPaymentMethodType:BTUIKPaymentOptionTypeApplePay nonce:nil error:nil];
+            [self.delegate selectionCompletedWithPaymentMethodType:BTUIKPaymentOptionTypeApplePay nonce:nil isRecentItem:false error:nil];
         }
     }
     [tableView deselectRowAtIndexPath:indexPath animated:YES];

--- a/BraintreeDropIn/BTPaymentSelectionViewController.m
+++ b/BraintreeDropIn/BTPaymentSelectionViewController.m
@@ -367,7 +367,7 @@
 - (void)collectionView:(__unused UICollectionView *)savedPaymentMethodsCollectionView didSelectItemAtIndexPath:(__unused NSIndexPath *)indexPath {
     BTUIPaymentMethodCollectionViewCell *cell = (BTUIPaymentMethodCollectionViewCell*)[savedPaymentMethodsCollectionView cellForItemAtIndexPath:indexPath];
     if (self.delegate) {
-        [self.delegate selectionCompletedWithPaymentMethodType:[BTUIKViewUtil paymentOptionTypeForPaymentInfoType:cell.paymentMethodNonce.type] nonce:cell.paymentMethodNonce isRecentItem:true error:nil];
+        [self.delegate selectionCompletedWithPaymentMethodType:[BTUIKViewUtil paymentOptionTypeForPaymentInfoType:cell.paymentMethodNonce.type] nonce:cell.paymentMethodNonce isVaultedItem:true error:nil];
     }
 }
 
@@ -415,7 +415,7 @@
         [[BTTokenizationService sharedService] tokenizeType:@"PayPal" options:options withAPIClient:self.apiClient completion:^(BTPaymentMethodNonce * _Nullable paymentMethodNonce, NSError * _Nullable error) {
             if (self.delegate && paymentMethodNonce != nil) {
                 BTUIKPaymentOptionType type = [BTUIKViewUtil paymentOptionTypeForPaymentInfoType:paymentMethodNonce.type];
-                [self.delegate selectionCompletedWithPaymentMethodType:type nonce:paymentMethodNonce isRecentItem:false error:error];
+                [self.delegate selectionCompletedWithPaymentMethodType:type nonce:paymentMethodNonce isVaultedItem:false error:error];
             }
         }];
         
@@ -426,12 +426,12 @@
         }
         [[BTTokenizationService sharedService] tokenizeType:@"Venmo" options:options withAPIClient:self.apiClient completion:^(BTPaymentMethodNonce * _Nullable paymentMethodNonce, NSError * _Nullable error) {
             if (self.delegate && paymentMethodNonce != nil) {
-                [self.delegate selectionCompletedWithPaymentMethodType:BTUIKPaymentOptionTypeVenmo nonce:paymentMethodNonce isRecentItem:false error:error];
+                [self.delegate selectionCompletedWithPaymentMethodType:BTUIKPaymentOptionTypeVenmo nonce:paymentMethodNonce isVaultedItem:false error:error];
             }
         }];
     } else if(cell.type == BTUIKPaymentOptionTypeApplePay) {
         if (self.delegate) {
-            [self.delegate selectionCompletedWithPaymentMethodType:BTUIKPaymentOptionTypeApplePay nonce:nil isRecentItem:false error:nil];
+            [self.delegate selectionCompletedWithPaymentMethodType:BTUIKPaymentOptionTypeApplePay nonce:nil isVaultedItem:false error:nil];
         }
     }
     [tableView deselectRowAtIndexPath:indexPath animated:YES];

--- a/BraintreeDropIn/Public/BTDropInResult.h
+++ b/BraintreeDropIn/Public/BTDropInResult.h
@@ -29,6 +29,9 @@ typedef void (^BTDropInResultFetchHandler)(BTDropInResult * _Nullable result, NS
 /// The payment method nonce
 @property (nonatomic, strong, nullable) BTPaymentMethodNonce *paymentMethod;
 
+/// True if user selected a recent item from the BTPaymentSelectionViewController collectionView.
+@property (nonatomic, assign, getter=isRecentItem) BOOL recentItem;
+
 /// Fetch a BTDropInResult without displaying or initializing a BTDropInController. Works with client tokens that
 /// were created with a `customer_id`.
 ///

--- a/BraintreeDropIn/Public/BTDropInResult.h
+++ b/BraintreeDropIn/Public/BTDropInResult.h
@@ -29,8 +29,8 @@ typedef void (^BTDropInResultFetchHandler)(BTDropInResult * _Nullable result, NS
 /// The payment method nonce
 @property (nonatomic, strong, nullable) BTPaymentMethodNonce *paymentMethod;
 
-/// True if user selected a recent item from the BTPaymentSelectionViewController collectionView.
-@property (nonatomic, assign, getter=isRecentItem) BOOL recentItem;
+/// True if user selected a vaulted item from the BTPaymentSelectionViewController collectionView.
+@property (nonatomic, assign, getter=isVaultedItem) BOOL vaultedItem;
 
 /// Fetch a BTDropInResult without displaying or initializing a BTDropInController. Works with client tokens that
 /// were created with a `customer_id`.

--- a/BraintreeDropIn/Public/BTPaymentSelectionViewController.h
+++ b/BraintreeDropIn/Public/BTPaymentSelectionViewController.h
@@ -32,8 +32,8 @@
 /// @param type The BTUIKPaymentOptionType of the selected payment method
 /// @param nonce The BTPaymentMethodNonce of the selected payment method. @note This can be `nil` in the case of Apple Pay.
 /// @param error The error that occured during tokenization of a new payment method.
-/// @param recentItem Boolean value to specify if the user selected a recent item.
-- (void) selectionCompletedWithPaymentMethodType:(BTUIKPaymentOptionType) type nonce:(BTPaymentMethodNonce *)nonce isRecentItem:(BOOL)recentItem error:(NSError *)error;
+/// @param vaultedItem Boolean value to specify if the user selected a vaulted item.
+- (void) selectionCompletedWithPaymentMethodType:(BTUIKPaymentOptionType) type nonce:(BTPaymentMethodNonce *)nonce isVaultedItem:(BOOL)vaultedItem error:(NSError *)error;
 
 /// Called on the delegate when the value return by BTPaymentSelectionViewController:sheetHeight has changed
 ///

--- a/BraintreeDropIn/Public/BTPaymentSelectionViewController.h
+++ b/BraintreeDropIn/Public/BTPaymentSelectionViewController.h
@@ -32,7 +32,8 @@
 /// @param type The BTUIKPaymentOptionType of the selected payment method
 /// @param nonce The BTPaymentMethodNonce of the selected payment method. @note This can be `nil` in the case of Apple Pay.
 /// @param error The error that occured during tokenization of a new payment method.
-- (void) selectionCompletedWithPaymentMethodType:(BTUIKPaymentOptionType) type nonce:(BTPaymentMethodNonce *)nonce error:(NSError *)error;
+/// @param recentItem Boolean value to specify if the user selected a recent item.
+- (void) selectionCompletedWithPaymentMethodType:(BTUIKPaymentOptionType) type nonce:(BTPaymentMethodNonce *)nonce isRecentItem:(BOOL)recentItem error:(NSError *)error;
 
 /// Called on the delegate when the value return by BTPaymentSelectionViewController:sheetHeight has changed
 ///


### PR DESCRIPTION
Would be nice to know if the customer used a new or vaulted card in the completion of the Drop-in for things like analytics etc.

[See issue 28](https://github.com/braintree/braintree-ios-drop-in/issues/28).