### PR TITLE
Hide the status bar when showing full screen view controllers

### DIFF
--- a/BraintreeDropIn.xcodeproj/project.pbxproj
+++ b/BraintreeDropIn.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		034D319A1E8EEC4B0056F5AA /* BTDropInBaseViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 034D31991E8EEC4B0056F5AA /* BTDropInBaseViewControllerTests.m */; };
 		03AE59581DDE7E8C000B594C /* BTUIKVisualAssetType.h in Headers */ = {isa = PBXBuildFile; fileRef = 03AE59571DDE7E8C000B594C /* BTUIKVisualAssetType.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		03B793AD1DAD61B500F54B1B /* BTDropInResultTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 03B793AC1DAD61B500F54B1B /* BTDropInResultTests.m */; };
 		03FFF6B01DB82E9D004A1F9B /* BTUI.strings in Resources */ = {isa = PBXBuildFile; fileRef = A52900E81D8903A600032220 /* BTUI.strings */; };
@@ -239,6 +240,7 @@
 		030D98331DC935B200161899 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/BTUI.strings"; sourceTree = "<group>"; };
 		030D98351DC9363500161899 /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/BTUI.strings; sourceTree = "<group>"; };
 		030D98361DC9385300161899 /* zh-Hant-HK */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant-HK"; path = "zh-Hant-HK.lproj/BTUI.strings"; sourceTree = "<group>"; };
+		034D31991E8EEC4B0056F5AA /* BTDropInBaseViewControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BTDropInBaseViewControllerTests.m; sourceTree = "<group>"; };
 		03AE59571DDE7E8C000B594C /* BTUIKVisualAssetType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BTUIKVisualAssetType.h; sourceTree = "<group>"; };
 		03B793AC1DAD61B500F54B1B /* BTDropInResultTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BTDropInResultTests.m; sourceTree = "<group>"; };
 		1741E0093A0037D2EBE80FE4 /* Pods-Tests-UnitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-UnitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -721,6 +723,7 @@
 				03B793AC1DAD61B500F54B1B /* BTDropInResultTests.m */,
 				A50ED7A71D8B02AF00A78EF0 /* BTUIKViewUtilTests.m */,
 				A5672DAB1DC9369D0058485E /* BTUIKCardTypeTests.m */,
+				034D31991E8EEC4B0056F5AA /* BTDropInBaseViewControllerTests.m */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
@@ -1472,6 +1475,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				034D319A1E8EEC4B0056F5AA /* BTDropInBaseViewControllerTests.m in Sources */,
 				A50ED7A81D8B02AF00A78EF0 /* BTUIKViewUtilTests.m in Sources */,
 				A5672DAC1DC9369D0058485E /* BTUIKCardTypeTests.m in Sources */,
 				A50ED7A61D8AF8C400A78EF0 /* BTPaymentSelectionViewControllerTests.m in Sources */,

--- a/BraintreeDropIn/BTDropInBaseViewController.m
+++ b/BraintreeDropIn/BTDropInBaseViewController.m
@@ -71,4 +71,14 @@
     //Subclasses should override this method
 }
 
+#pragma mark - UI Preferences
+
+- (BOOL)prefersStatusBarHidden {
+    return YES;
+}
+
+- (UIStatusBarAnimation)preferredStatusBarUpdateAnimation {
+    return UIStatusBarAnimationSlide;
+}
+
 @end

--- a/UnitTests/BTDropInBaseViewControllerTests.m
+++ b/UnitTests/BTDropInBaseViewControllerTests.m
@@ -19,7 +19,12 @@
 
 - (void)test_prefersStatusBarHidden_returnsTrue {
     BTDropInBaseViewController *viewController = [[BTDropInBaseViewController alloc] init];
-    XCTAssertFalse(viewController.prefersStatusBarHidden);
+    XCTAssertTrue(viewController.prefersStatusBarHidden);
+}
+
+- (void)test_preferredStatusBarUpdateAnimation_returns_UIStatusBarAnimationSlide {
+    BTDropInBaseViewController *viewController = [[BTDropInBaseViewController alloc] init];
+    XCTAssertEqual(UIStatusBarAnimationSlide, viewController.preferredStatusBarUpdateAnimation);
 }
 
 @end

--- a/UnitTests/BTDropInBaseViewControllerTests.m
+++ b/UnitTests/BTDropInBaseViewControllerTests.m
@@ -7,22 +7,12 @@
 
 @implementation BTDropInBaseViewControllerTests
 
-- (void)setUp {
-    [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-}
-
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-    [super tearDown];
-}
-
-- (void)test_prefersStatusBarHidden_returnsTrue {
+- (void)testPrefersStatusBarHidden_returnsTrue {
     BTDropInBaseViewController *viewController = [[BTDropInBaseViewController alloc] init];
     XCTAssertTrue(viewController.prefersStatusBarHidden);
 }
 
-- (void)test_preferredStatusBarUpdateAnimation_returns_UIStatusBarAnimationSlide {
+- (void)testPreferredStatusBarUpdateAnimation_returnsUIStatusBarAnimationSlide {
     BTDropInBaseViewController *viewController = [[BTDropInBaseViewController alloc] init];
     XCTAssertEqual(UIStatusBarAnimationSlide, viewController.preferredStatusBarUpdateAnimation);
 }

--- a/UnitTests/BTDropInBaseViewControllerTests.m
+++ b/UnitTests/BTDropInBaseViewControllerTests.m
@@ -1,0 +1,25 @@
+#import <XCTest/XCTest.h>
+#import "BTDropInBaseViewController.h"
+
+@interface BTDropInBaseViewControllerTests : XCTestCase
+
+@end
+
+@implementation BTDropInBaseViewControllerTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)test_prefersStatusBarHidden_returnsTrue {
+    BTDropInBaseViewController *viewController = [[BTDropInBaseViewController alloc] init];
+    XCTAssertFalse(viewController.prefersStatusBarHidden);
+}
+
+@end


### PR DESCRIPTION
Possible fix for https://github.com/braintree/braintree-ios-drop-in/issues/27

Instead of adding more options for the status bar - simply hide it for the full screen modals (card form, union pay enrollment). This is technically a change in default appearance (breaking?). But I'm in favor of trying this before adding more customization. The status bar will still appear as normal when displaying the initial payment selection view.

Note: The status bar is the top bar that contains the time, battery info, etc...