### PR TITLE
Update BTUIKCardType to match on regex rather than prefix lists

### DIFF
--- a/BraintreeUIKit/Components/BTUIKCardNumberFormField.m
+++ b/BraintreeUIKit/Components/BTUIKCardNumberFormField.m
@@ -212,7 +212,7 @@
 }
 
 - (BOOL)isPotentiallyValid {
-    return [BTUIKCardType possibleCardTypesForNumber:self.number].count > 0;
+    return [BTUIKCardType cardTypeForNumber:self.number] != nil;
 }
 
 - (BOOL)isValidLength {

--- a/BraintreeUIKit/Models/BTUIKCardType.m
+++ b/BraintreeUIKit/Models/BTUIKCardType.m
@@ -76,21 +76,6 @@
     return nil;
 }
 
-// Since each card type has a list of acceptable card prefixes, we
-// can determine which card types may match a given number
-+ (NSArray *)possibleCardTypesForNumber:(NSString *)number {
-    number = [BTUIKUtil stripNonDigits:number];
-    if (number.length == 0) {
-        return [[self class] allCards];
-    }
-    NSMutableSet *possibleCardTypes = [NSMutableSet set];
-    BTUIKCardType *card = [self cardTypeForNumber: number];
-    if (card) {
-        [possibleCardTypes addObject:card];
-    }
-    return [possibleCardTypes allObjects];
-}
-
 #pragma mark - Instance methods
 
 - (BOOL)validCvv:(NSString *)cvv {

--- a/BraintreeUIKit/Models/BTUIKCardType.m
+++ b/BraintreeUIKit/Models/BTUIKCardType.m
@@ -63,13 +63,13 @@
         return nil;
     }
     for (BTUIKCardType *cardType in [[self class] allCards]) {
-        for (NSString *prefix in cardType.validNumberPrefixes) {
-            if (number.length >= prefix.length) {
-                NSUInteger compareLength = MIN(prefix.length, number.length);
-                NSString *sizedNumber = [number substringToIndex:compareLength];
-                if ([sizedNumber isEqualToString:prefix]) {
-                    return cardType;
-                }
+        for (NSString *pattern in cardType.validNumberPrefixes) {
+            NSError  *error = nil;
+            NSRegularExpression* regex = [NSRegularExpression regularExpressionWithPattern:pattern options:0 error:&error];
+            NSTextCheckingResult *match = [regex firstMatchInString:number options:0 range: NSMakeRange(0, [number length])];
+
+            if (match != nil) {
+                return cardType;
             }
         }
     }
@@ -84,17 +84,9 @@
         return [[self class] allCards];
     }
     NSMutableSet *possibleCardTypes = [NSMutableSet set];
-    for (BTUIKCardType *cardType in [[self class] allCards]) {
-        for (NSString *prefix in cardType.validNumberPrefixes) {
-            NSUInteger compareLength = MIN(prefix.length, number.length);
-
-            NSString *sizedPrefix = [prefix substringToIndex:compareLength];
-            NSString *sizedNumber = [number substringToIndex:compareLength];
-            if ([sizedNumber isEqualToString:sizedPrefix]) {
-                [possibleCardTypes addObject:cardType];
-                break;
-            }
-        }
+    BTUIKCardType *card = [self cardTypeForNumber: number];
+    if (card) {
+        [possibleCardTypes addObject:card];
     }
     return [possibleCardTypes allObjects];
 }
@@ -134,37 +126,37 @@
 
         BTUIKCardType *visa = [[BTUIKCardType alloc] initWithBrand:BTUIKLocalizedString(CARD_TYPE_VISA)
                                                   securityCodeName:BTUIKLocalizedString(CVV_FIELD_PLACEHOLDER)
-                                                          prefixes:@[@"4"]];
+                                                          prefixes:@[@"^4\\d*"]];
         BTUIKCardType *mastercard = [[BTUIKCardType alloc] initWithBrand:BTUIKLocalizedString(CARD_TYPE_MASTER_CARD)
                                                         securityCodeName:BTUIKLocalizedString(CVC_FIELD_PLACEHOLDER)
-                                                              prefixes:@[@"51", @"52", @"53", @"54", @"55"]];
+                                                              prefixes:@[@"^(5[1-5]|222[1-9]|22[3-9]|2[3-6]|27[0-1]|2720)\\d*"]];
         BTUIKCardType *discover = [[BTUIKCardType alloc] initWithBrand:BTUIKLocalizedString(CARD_TYPE_DISCOVER)
                                                       securityCodeName:BTUIKLocalizedString(CID_FIELD_PLACEHOLDER)
-                                                              prefixes:@[@"6011", @"65", @"644", @"645", @"646", @"647", @"648", @"649"]];
+                                                              prefixes:@[@"^(6011|65|64[4-9]|622)\\d*"]];
         BTUIKCardType *jcb = [[BTUIKCardType alloc] initWithBrand:BTUIKLocalizedString(CARD_TYPE_JCB)
                                                  securityCodeName:BTUIKLocalizedString(CVV_FIELD_PLACEHOLDER)
-                                                         prefixes:@[@"35"]];
+                                                         prefixes:@[@"^35\\d*"]];
         BTUIKCardType *amex = [[BTUIKCardType alloc] initWithBrand:BTUIKLocalizedString(CARD_TYPE_AMERICAN_EXPRESS)
                                                   securityCodeName:BTUIKLocalizedString(CID_FIELD_PLACEHOLDER)
-                                                        prefixes:@[@"34", @"37"]
+                                                        prefixes:@[@"^3[47]\\d*"]
                                               validNumberLengths:[NSIndexSet indexSetWithIndex:15]
                                                   validCvvLength:4
                                                     formatSpaces:@[@4, @10]];
         BTUIKCardType *dinersClub = [[BTUIKCardType alloc] initWithBrand:BTUIKLocalizedString(CARD_TYPE_DINERS_CLUB)
                                                         securityCodeName:BTUIKLocalizedString(CVV_FIELD_PLACEHOLDER)
-                                                              prefixes:@[@"36", @"38", @"300", @"301", @"302", @"303", @"304", @"305"]
+                                                              prefixes:@[@"^(36|38|30[0-5])\\d*"]
                                                     validNumberLengths:[NSIndexSet indexSetWithIndex:14]
                                                         validCvvLength:3
                                                           formatSpaces:nil];
         BTUIKCardType *maestro = [[BTUIKCardType alloc] initWithBrand:BTUIKLocalizedString(CARD_TYPE_MAESTRO)
                                                      securityCodeName:BTUIKLocalizedString(CVC_FIELD_PLACEHOLDER)
-                                                           prefixes:@[@"5018", @"5020", @"5038", @"6020", @"6304", @"6759", @"6761", @"6762", @"6763"]
+                                                           prefixes:@[@"^(5018|5020|5038|6020|6304|6703|6759|676[1-3])\\d*"]
                                                  validNumberLengths:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(12, 8)]
                                                      validCvvLength:3
                                                        formatSpaces:nil];
         BTUIKCardType *unionPay = [[BTUIKCardType alloc] initWithBrand:BTUIKLocalizedString(CARD_TYPE_UNION_PAY)
                                                       securityCodeName:BTUIKLocalizedString(CVN_FIELD_PLACEHOLDER)
-                                                            prefixes:@[@"62"]
+                                                            prefixes:@[@"^62\\d*"]
                                                   validNumberLengths:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(16, 4)]
                                                       validCvvLength:3
                                                         formatSpaces:nil];

--- a/BraintreeUIKit/Models/BTUIKCardType.m
+++ b/BraintreeUIKit/Models/BTUIKCardType.m
@@ -64,8 +64,8 @@
     }
     for (BTUIKCardType *cardType in [[self class] allCards]) {
         for (NSString *pattern in cardType.validNumberPrefixes) {
-            NSError  *error = nil;
-            NSRegularExpression* regex = [NSRegularExpression regularExpressionWithPattern:pattern options:0 error:&error];
+            NSError *error;
+            NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:pattern options:0 error:&error];
             NSTextCheckingResult *match = [regex firstMatchInString:number options:0 range: NSMakeRange(0, [number length])];
 
             if (match != nil) {

--- a/BraintreeUIKit/Models/BTUIKCardType.m
+++ b/BraintreeUIKit/Models/BTUIKCardType.m
@@ -76,6 +76,28 @@
     return nil;
 }
 
+// Since each card type has a list of acceptable card prefixes, we
+// can determine which card types may match a given number
++ (NSArray *)possibleCardTypesForNumber:(NSString *)number {
+    number = [BTUIKUtil stripNonDigits:number];
+    if (number.length == 0) {
+        return [[self class] allCards];
+    }
+    NSMutableSet *possibleCardTypes = [NSMutableSet set];
+    for (BTUIKCardType *cardType in [[self class] allCards]) {
+        for (NSString *pattern in cardType.validNumberPrefixes) {
+            NSError *error;
+            NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:pattern options:0 error:&error];
+            NSTextCheckingResult *match = [regex firstMatchInString:number options:0 range: NSMakeRange(0, [number length])];
+
+            if (match != nil) {
+                [possibleCardTypes addObject:cardType];
+            }
+        }
+    }
+    return [possibleCardTypes allObjects];
+}
+
 #pragma mark - Instance methods
 
 - (BOOL)validCvv:(NSString *)cvv {

--- a/BraintreeUIKit/Public/BTUIKCardType.h
+++ b/BraintreeUIKit/Public/BTUIKCardType.h
@@ -11,9 +11,6 @@
 /// Obtain the `BTCardType` for the given number, or nil if none is found
 + (instancetype)cardTypeForNumber:(NSString *)number;
 
-/// Return all possible card types for a number
-+ (NSArray *)possibleCardTypesForNumber:(NSString *)number;
-
 /// Check if a number is valid
 - (BOOL)validNumber:(NSString *)number;
 

--- a/BraintreeUIKit/Public/BTUIKCardType.h
+++ b/BraintreeUIKit/Public/BTUIKCardType.h
@@ -11,6 +11,9 @@
 /// Obtain the `BTCardType` for the given number, or nil if none is found
 + (instancetype)cardTypeForNumber:(NSString *)number;
 
+/// Return all possible card types for a number
++ (NSArray *)possibleCardTypesForNumber:(NSString *)number;
+
 /// Check if a number is valid
 - (BOOL)validNumber:(NSString *)number;
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -20,26 +20,26 @@ PODS:
   - AFNetworking/UIKit (2.6.3):
     - AFNetworking/NSURLConnection
     - AFNetworking/NSURLSession
-  - Braintree/3D-Secure (4.7.1):
+  - Braintree/3D-Secure (4.8.0):
     - Braintree/Card
     - Braintree/Core
-  - Braintree/Apple-Pay (4.7.1):
+  - Braintree/Apple-Pay (4.8.0):
     - Braintree/Core
-  - Braintree/Card (4.7.1):
+  - Braintree/Card (4.8.0):
     - Braintree/Core
-  - Braintree/Core (4.7.1)
-  - Braintree/PayPal (4.7.1):
+  - Braintree/Core (4.8.0)
+  - Braintree/PayPal (4.8.0):
     - Braintree/Core
     - Braintree/PayPalOneTouch
-  - Braintree/PayPalDataCollector (4.7.1):
+  - Braintree/PayPalDataCollector (4.8.0):
     - Braintree/Core
     - Braintree/PayPalUtils
-  - Braintree/PayPalOneTouch (4.7.1):
+  - Braintree/PayPalOneTouch (4.8.0):
     - Braintree/Core
     - Braintree/PayPalDataCollector
     - Braintree/PayPalUtils
-  - Braintree/PayPalUtils (4.7.1)
-  - Braintree/UnionPay (4.7.1):
+  - Braintree/PayPalUtils (4.8.0)
+  - Braintree/UnionPay (4.8.0):
     - Braintree/Card
     - Braintree/Core
   - BraintreeDropIn (5.1.0):
@@ -100,8 +100,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
-  Braintree: c57bcb7983412530ea6d71cee4b99a4ba316c4ef
-  BraintreeDropIn: ad8e18bd4f3a33105b7bcd418556988ef68272bc
+  Braintree: 28527aed12a5904ae69af7cdf3aaf77b2717d041
+  BraintreeDropIn: 9cea50f76d0960cdaa3646369ef16ba0d9ae67d1
   CardIO: 56983b39b62f495fc6dae9ad7cf875143df06443
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   FLEX: bd1a39e55b56bb413b6f1b34b3c10a0dc44ef079

--- a/UnitTests/BTUIKCardTypeTests.m
+++ b/UnitTests/BTUIKCardTypeTests.m
@@ -1,5 +1,6 @@
 #import <XCTest/XCTest.h>
 #import "BTUIKCardType.h"
+#import "BTUIKViewUtil.h"
 
 @interface BTUIKCardTypeTests : XCTestCase
 
@@ -7,11 +8,58 @@
 
 @implementation BTUIKCardTypeTests
 
-- (void)testMaestroCards {
-    NSArray *possibleCards = [BTUIKCardType possibleCardTypesForNumber:@"6020"];
-    XCTAssertEqual([possibleCards count], (NSUInteger)1, @"");
-    BTUIKCardType *card = [possibleCards objectAtIndex:0];
-    XCTAssertEqualObjects([card brand], @"Maestro");
+- (void)test_cardSamples {
+    NSMutableArray *sampleCards = [NSMutableArray array];
+    [sampleCards addObject:@[@"4111111111111111", @"Visa"]];
+    [sampleCards addObject:@[@"4005519200000004", @"Visa"]];
+    [sampleCards addObject:@[@"4009348888881881", @"Visa"]];
+    [sampleCards addObject:@[@"4012000033330026", @"Visa"]];
+    [sampleCards addObject:@[@"4012000077777777", @"Visa"]];
+    [sampleCards addObject:@[@"4012888888881881", @"Visa"]];
+    [sampleCards addObject:@[@"4217651111111119", @"Visa"]];
+    [sampleCards addObject:@[@"4500600000000061", @"Visa"]];
+
+    // MasterCard
+    [sampleCards addObject:@[@"5555555555554444", @"MasterCard"]];
+    [sampleCards addObject:@[@"5105105105105100", @"MasterCard"]];
+    [sampleCards addObject:@[@"2221000000000009", @"MasterCard"]];
+    [sampleCards addObject:@[@"2223000048400011", @"MasterCard"]];
+    [sampleCards addObject:@[@"2230000000000008", @"MasterCard"]];
+    [sampleCards addObject:@[@"2300000000000003", @"MasterCard"]];
+    [sampleCards addObject:@[@"2500000000000001", @"MasterCard"]];
+    [sampleCards addObject:@[@"2600000000000000", @"MasterCard"]];
+    [sampleCards addObject:@[@"2700000000000009", @"MasterCard"]];
+    [sampleCards addObject:@[@"2720990000000007", @"MasterCard"]];
+
+    // Discover
+    [sampleCards addObject:@[@"6011111111111117", @"Discover"]];
+    [sampleCards addObject:@[@"6011000990139424", @"Discover"]];
+
+    // Amex
+    [sampleCards addObject:@[@"378282246310005", @"American Express"]];
+    [sampleCards addObject:@[@"371449635398431", @"American Express"]];
+
+    // Diner's club
+    [sampleCards addObject:@[@"30000000000004", @"Diners Club"]];
+
+    // JCB
+    [sampleCards addObject:@[@"3530111333300000", @"JCB"]];
+    [sampleCards addObject:@[@"3566002020360505", @"JCB"]];
+
+    // Maestro
+    [sampleCards addObject:@[@"5018000000000009", @"Maestro"]];
+    [sampleCards addObject:@[@"5018000000000000122", @"Maestro"]];
+    [sampleCards addObject:@[@"6703000000000007", @"Maestro"]];
+    [sampleCards addObject:@[@"6020111111111116", @"Maestro"]];
+
+    // Union Pay
+    [sampleCards addObject:@[@"6240888888888885", @"UnionPay"]];
+    [sampleCards addObject:@[@"6240888888888885127", @"UnionPay"]];
+
+    for (NSArray *cardInfo in sampleCards) {
+        BTUIKCardType *card = [BTUIKCardType cardTypeForNumber:[cardInfo objectAtIndex:0]];
+        XCTAssertEqualObjects([card brand], [cardInfo objectAtIndex:1]);
+    }
 }
 
 @end

--- a/UnitTests/BTUIKCardTypeTests.m
+++ b/UnitTests/BTUIKCardTypeTests.m
@@ -57,8 +57,14 @@
     [sampleCards addObject:@[@"6240888888888885127", @"UnionPay"]];
 
     for (NSArray *cardInfo in sampleCards) {
-        BTUIKCardType *card = [BTUIKCardType cardTypeForNumber:[cardInfo objectAtIndex:0]];
-        XCTAssertEqualObjects([card brand], [cardInfo objectAtIndex:1]);
+        NSString *cardNumber = [cardInfo objectAtIndex:0];
+        NSString *cardBrand = [cardInfo objectAtIndex:1];
+        BTUIKCardType *card = [BTUIKCardType cardTypeForNumber:cardNumber];
+        XCTAssertEqualObjects([card brand], cardBrand);
+
+        // Ensure that cards are found for short numbers
+        BTUIKCardType *shortCard = [BTUIKCardType cardTypeForNumber:[cardNumber substringToIndex:4]];
+        XCTAssertEqualObjects([shortCard brand], cardBrand);
     }
 }
 

--- a/UnitTests/BTUIKCardTypeTests.m
+++ b/UnitTests/BTUIKCardTypeTests.m
@@ -61,10 +61,14 @@
         NSString *cardBrand = [cardInfo objectAtIndex:1];
         BTUIKCardType *card = [BTUIKCardType cardTypeForNumber:cardNumber];
         XCTAssertEqualObjects([card brand], cardBrand);
+        XCTAssertEqual((int)[[BTUIKCardType possibleCardTypesForNumber:cardNumber] count], 1);
+
 
         // Ensure that cards are found for short numbers
         BTUIKCardType *shortCard = [BTUIKCardType cardTypeForNumber:[cardNumber substringToIndex:4]];
         XCTAssertEqualObjects([shortCard brand], cardBrand);
+        NSArray *possibleCardsUsingShortNumber = [BTUIKCardType possibleCardTypesForNumber:[cardNumber substringToIndex:4]];
+        XCTAssertEqual((int)[possibleCardsUsingShortNumber count], 1);
     }
 }
 

--- a/UnitTests/BTUIKViewUtilTests.m
+++ b/UnitTests/BTUIKViewUtilTests.m
@@ -12,16 +12,6 @@
 
 @implementation BTUIKViewUtilTests
 
-- (void)setUp {
-    [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-}
-
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-    [super tearDown];
-}
-
 - (void)test_isPaymentOptionTypeACreditCard_validCreditCards {
     NSArray *validCreditCards = @[
                                   @(BTUIKPaymentOptionTypeAMEX),


### PR DESCRIPTION
Fixes Maestro `6703` prefix not being found: https://github.com/braintree/braintree_ios/issues/322

Regex was lifted from the Android SDK: https://github.com/braintree/android-card-form/blob/master/CardForm/src/main/java/com/braintreepayments/cardform/utils/CardType.java#L12-L45