### PR TITLE
Use OverCurrentContext for the card form modal when not an iPad device

### DIFF
--- a/BraintreeDropIn/BTDropInController.m
+++ b/BraintreeDropIn/BTDropInController.m
@@ -299,9 +299,11 @@
     BTCardFormViewController* vd = [[BTCardFormViewController alloc] initWithAPIClient:self.apiClient request:self.dropInRequest];
     vd.supportedCardTypes = self.displayCardTypes;
     vd.delegate = self;
-      UINavigationController* navController = [[UINavigationController alloc] initWithRootViewController:vd];
+    UINavigationController* navController = [[UINavigationController alloc] initWithRootViewController:vd];
     if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad) {
         navController.modalPresentationStyle = UIModalPresentationPageSheet;
+    } else {
+        navController.modalPresentationStyle = UIModalPresentationOverCurrentContext;
     }
     [self presentViewController:navController animated:YES completion:nil];
 }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -42,14 +42,14 @@ PODS:
   - Braintree/UnionPay (4.8.0):
     - Braintree/Card
     - Braintree/Core
-  - BraintreeDropIn (5.1.0):
-    - BraintreeDropIn/DropIn (= 5.1.0)
-  - BraintreeDropIn/DropIn (5.1.0):
+  - BraintreeDropIn (5.2.0):
+    - BraintreeDropIn/DropIn (= 5.2.0)
+  - BraintreeDropIn/DropIn (5.2.0):
     - Braintree/Card (~> 4.0)
     - Braintree/Core (~> 4.0)
     - Braintree/UnionPay (~> 4.0)
     - BraintreeDropIn/UIKit
-  - BraintreeDropIn/UIKit (5.1.0)
+  - BraintreeDropIn/UIKit (5.2.0)
   - CardIO (5.4.1)
   - Expecta (1.0.5)
   - FLEX (2.4.0)
@@ -101,7 +101,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
   Braintree: 28527aed12a5904ae69af7cdf3aaf77b2717d041
-  BraintreeDropIn: 9cea50f76d0960cdaa3646369ef16ba0d9ae67d1
+  BraintreeDropIn: f4278c4eafc1395d06ce79652fa1658d2b5ab815
   CardIO: 56983b39b62f495fc6dae9ad7cf875143df06443
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   FLEX: bd1a39e55b56bb413b6f1b34b3c10a0dc44ef079

--- a/UITests/BraintreeDropIn_UITests.swift
+++ b/UITests/BraintreeDropIn_UITests.swift
@@ -23,7 +23,7 @@ class BraintreeDropIn_TokenizationKey_CardForm_UITests: XCTestCase {
         app.buttons["Add Payment Method"].tap()
     }
 
-    func testDropIn_dismessesWhenCancelled() {
+    func testDropIn_dismissesWhenCancelled() {
         self.waitForElementToBeHittable(app.buttons["Cancel"])
         app.buttons["Cancel"].forceTapElement()
         XCTAssertTrue(app.buttons["Cancelled🎲"].exists);
@@ -343,33 +343,34 @@ class BraintreeDropIn_ThreeDSecure_UITests: XCTestCase {
     func testDropIn_threeDSecure_returnsToPaymentSelectionView_whenCancelled() {
         self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
         app.staticTexts["Credit or Debit Card"].tap()
-        
+
         let elementsQuery = app.scrollViews.otherElements
         let cardNumberTextField = elementsQuery.textFields["Card Number"]
-        
+
         self.waitForElementToBeHittable(cardNumberTextField)
         cardNumberTextField.typeText("4111111111111111")
-        
+
         self.waitForElementToBeHittable(app.staticTexts["2019"])
         app.staticTexts["11"].forceTapElement()
         app.staticTexts["2019"].forceTapElement()
-        
+
         let securityCodeField = elementsQuery.textFields["CVV"]
         self.waitForElementToBeHittable(securityCodeField)
         securityCodeField.forceTapElement()
         securityCodeField.typeText("123")
-        
+
         let postalCodeField = elementsQuery.textFields["12345"]
         self.waitForElementToBeHittable(postalCodeField)
         postalCodeField.forceTapElement()
         postalCodeField.typeText("12345")
-        
+
         app.buttons["Add Card"].forceTapElement()
-        
+
         self.waitForElementToAppear(app.staticTexts["Added Protection"])
-        
-        self.waitForElementToBeHittable(app.buttons["Cancel"])
-        app.buttons["Cancel"].forceTapElement()
+
+        self.waitForElementToAppear(app.navigationBars["Authentication"])
+
+        app.navigationBars["Authentication"].buttons["Cancel"].forceTapElement()
         self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
         self.waitForElementToAppear(app.staticTexts["Select Payment Method"])
         


### PR DESCRIPTION
Corrects an issues where the Card Form was not inheriting the current context and would behave differently (e.g. auto rotation).