### PR TITLE
Fix empty result during PayPal Cancel

### DIFF
--- a/BraintreeDropIn/BTPaymentSelectionViewController.m
+++ b/BraintreeDropIn/BTPaymentSelectionViewController.m
@@ -417,7 +417,7 @@
         }
         
         [[BTTokenizationService sharedService] tokenizeType:@"PayPal" options:options withAPIClient:self.apiClient completion:^(BTPaymentMethodNonce * _Nullable paymentMethodNonce, NSError * _Nullable error) {
-            if (self.delegate) {
+            if (self.delegate && (paymentMethodNonce != nil || error != nil)) {
                 [self.delegate selectionCompletedWithPaymentMethodType:BTUIKPaymentOptionTypePayPal nonce:paymentMethodNonce error:error];
             }
         }];
@@ -428,7 +428,7 @@
             options[BTTokenizationServiceViewPresentingDelegateOption] = self.delegate;
         }
         [[BTTokenizationService sharedService] tokenizeType:@"Venmo" options:options withAPIClient:self.apiClient completion:^(BTPaymentMethodNonce * _Nullable paymentMethodNonce, NSError * _Nullable error) {
-            if (self.delegate) {
+            if (self.delegate && (paymentMethodNonce != nil || error != nil)) {
                 [self.delegate selectionCompletedWithPaymentMethodType:BTUIKPaymentOptionTypeVenmo nonce:paymentMethodNonce error:error];
             }
         }];

--- a/UITests/BraintreeDropIn_UITests.swift
+++ b/UITests/BraintreeDropIn_UITests.swift
@@ -280,7 +280,27 @@ class BraintreeDropIn_PayPal_UITests: XCTestCase {
         
         self.waitForElementToAppear(app.staticTexts["bt_buyer_us@paypal.com"])
         
-        XCTAssertTrue(app.staticTexts["bt_buyer_us@paypal.com"].exists);
+        XCTAssertTrue(app.staticTexts["bt_buyer_us@paypal.com"].exists)
+    }
+
+    func testDropIn_paypal_cancelPopupShowsSelectPaymentMethodView() {
+        if #available(iOS 11.0, *) {
+            return
+        }
+
+        self.waitForElementToBeHittable(app.staticTexts["PayPal"])
+        app.staticTexts["PayPal"].tap()
+        sleep(3)
+
+        let webviewElementsQuery = app.webViews.element.otherElements
+
+        self.waitForElementToBeHittable(webviewElementsQuery.links["Cancel Sandbox Purchase"])
+
+        webviewElementsQuery.links["Cancel Sandbox Purchase"].forceTapElement()
+
+        self.waitForElementToAppear(app.staticTexts["Select Payment Method"])
+
+        XCTAssertTrue(app.staticTexts["Select Payment Method"].exists)
     }
 }
 


### PR DESCRIPTION
When canceling a PayPal payment, the `BTDropInResult`'s result has `isCancelled == false` and the payment method is empty. This PR fixes it so that canceling PayPal will result in the `Select Payment Method` view staying on screen without a result returned yet to allow the customer to select a different payment method if desired.