### PR TITLE
Remove duplicates from BTUIKCardListLabel

### DIFF
--- a/BraintreeDropIn.xcodeproj/project.pbxproj
+++ b/BraintreeDropIn.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		031F576F1E8EE0FB0013B5ED /* BTUIKAppearanceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 031F576E1E8EE0FB0013B5ED /* BTUIKAppearanceTests.m */; };
+		034B5C13203CDFD0001A01DE /* BTUIKCardListLabelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 034B5C12203CDFD0001A01DE /* BTUIKCardListLabelTests.m */; };
 		034D319A1E8EEC4B0056F5AA /* BTDropInBaseViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 034D31991E8EEC4B0056F5AA /* BTDropInBaseViewControllerTests.m */; };
 		0367AB4D1FC510AB00F8EF56 /* BTDropInOverrides.h in Headers */ = {isa = PBXBuildFile; fileRef = 039C17691FC4F1C000D5A3B5 /* BTDropInOverrides.h */; };
 		039C176C1FC4F1C000D5A3B5 /* BTDropInOverrides.m in Sources */ = {isa = PBXBuildFile; fileRef = 039C176A1FC4F1C000D5A3B5 /* BTDropInOverrides.m */; };
@@ -243,6 +244,7 @@
 		030D98351DC9363500161899 /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/BTUI.strings; sourceTree = "<group>"; };
 		030D98361DC9385300161899 /* zh-Hant-HK */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant-HK"; path = "zh-Hant-HK.lproj/BTUI.strings"; sourceTree = "<group>"; };
 		031F576E1E8EE0FB0013B5ED /* BTUIKAppearanceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BTUIKAppearanceTests.m; sourceTree = "<group>"; };
+		034B5C12203CDFD0001A01DE /* BTUIKCardListLabelTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BTUIKCardListLabelTests.m; sourceTree = "<group>"; };
 		034D31991E8EEC4B0056F5AA /* BTDropInBaseViewControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BTDropInBaseViewControllerTests.m; sourceTree = "<group>"; };
 		039C17691FC4F1C000D5A3B5 /* BTDropInOverrides.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BTDropInOverrides.h; sourceTree = "<group>"; };
 		039C176A1FC4F1C000D5A3B5 /* BTDropInOverrides.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BTDropInOverrides.m; sourceTree = "<group>"; };
@@ -729,6 +731,7 @@
 				A5672DAB1DC9369D0058485E /* BTUIKCardTypeTests.m */,
 				031F576E1E8EE0FB0013B5ED /* BTUIKAppearanceTests.m */,
 				034D31991E8EEC4B0056F5AA /* BTDropInBaseViewControllerTests.m */,
+				034B5C12203CDFD0001A01DE /* BTUIKCardListLabelTests.m */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
@@ -1497,6 +1500,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				034D319A1E8EEC4B0056F5AA /* BTDropInBaseViewControllerTests.m in Sources */,
+				034B5C13203CDFD0001A01DE /* BTUIKCardListLabelTests.m in Sources */,
 				A50ED7A81D8B02AF00A78EF0 /* BTUIKViewUtilTests.m in Sources */,
 				A5672DAC1DC9369D0058485E /* BTUIKCardTypeTests.m in Sources */,
 				031F576F1E8EE0FB0013B5ED /* BTUIKAppearanceTests.m in Sources */,

--- a/BraintreeUIKit/Components/BTUIKCardListLabel.m
+++ b/BraintreeUIKit/Components/BTUIKCardListLabel.m
@@ -40,7 +40,7 @@
 }
 
 - (void)setAvailablePaymentOptions:(NSArray *)availablePaymentOptions {
-    _availablePaymentOptions = availablePaymentOptions;
+    _availablePaymentOptions = [[NSSet setWithArray:availablePaymentOptions] allObjects];
     if ([BTUIKViewUtil isLanguageLayoutDirectionRightToLeft]) {
         _availablePaymentOptions = [[_availablePaymentOptions reverseObjectEnumerator] allObjects];
     }

--- a/UnitTests/BTUIKCardListLabelTests.m
+++ b/UnitTests/BTUIKCardListLabelTests.m
@@ -1,0 +1,19 @@
+#import <XCTest/XCTest.h>
+
+#import "BTUIKCardListLabel.h"
+
+@interface BTUIKCardListLabelTests : XCTestCase
+
+@end
+
+@implementation BTUIKCardListLabelTests
+
+- (void)test_cardListLabel_removesDuplicates {
+    BTUIKCardListLabel *cardListLabel = [[BTUIKCardListLabel alloc] init];
+    cardListLabel.availablePaymentOptions = @[@"Visa", @"Visa", @"Discover", @"Visa"];
+    XCTAssertTrue([cardListLabel.availablePaymentOptions count] == 2, @"The array should contain 1 instance of Visa and Discover." );
+    XCTAssertTrue([cardListLabel.availablePaymentOptions containsObject:@"Visa"]);
+    XCTAssertTrue([cardListLabel.availablePaymentOptions containsObject:@"Discover"]);
+}
+
+@end

--- a/UnitTests/BTUIKCardListLabelTests.m
+++ b/UnitTests/BTUIKCardListLabelTests.m
@@ -11,7 +11,7 @@
 - (void)test_cardListLabel_removesDuplicates {
     BTUIKCardListLabel *cardListLabel = [[BTUIKCardListLabel alloc] init];
     cardListLabel.availablePaymentOptions = @[@"Visa", @"Visa", @"Discover", @"Visa"];
-    XCTAssertTrue([cardListLabel.availablePaymentOptions count] == 2, @"The array should contain 1 instance of Visa and Discover." );
+    XCTAssertEqual([cardListLabel.availablePaymentOptions count], (NSUInteger)2);
     XCTAssertTrue([cardListLabel.availablePaymentOptions containsObject:@"Visa"]);
     XCTAssertTrue([cardListLabel.availablePaymentOptions containsObject:@"Discover"]);
 }


### PR DESCRIPTION
Ensure that duplicates are removed from the `BTUIKCardListLabel` when setting the `availablePaymentOptions`.