### PR TITLE
Display alert when tokenization fails on card form.

### DIFF
--- a/BraintreeDropIn/BTCardFormViewController.m
+++ b/BraintreeDropIn/BTCardFormViewController.m
@@ -598,6 +598,7 @@
     UIBarButtonItem *addCardButton = self.navigationItem.rightBarButtonItem;
     self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithCustomView:spinner];
     self.view.userInteractionEnabled = NO;
+    __block UINavigationController *navController = self.navigationController;
 
     [cardClient tokenizeCard:cardRequest options:nil completion:^(BTCardNonce * _Nullable tokenizedCard, NSError * _Nullable error) {
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -627,7 +628,16 @@
                     }
                 }];
             } else {
-                [self.delegate cardTokenizationCompleted:tokenizedCard error:error sender:self];
+                if (error != nil) {
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                        UIAlertController *alertController = [UIAlertController alertControllerWithTitle:BTUIKLocalizedString(CARD_DETAILS_LABEL) message:BTUIKLocalizedString(REVIEW_AND_TRY_AGAIN) preferredStyle:UIAlertControllerStyleAlert];
+                        UIAlertAction *alertAction = [UIAlertAction actionWithTitle:BTUIKLocalizedString(TOP_LEVEL_ERROR_ALERT_VIEW_OK_BUTTON_TEXT) style:UIAlertActionStyleDefault handler:nil];
+                        [alertController addAction: alertAction];
+                        [navController presentViewController:alertController animated:YES completion:nil];
+                    });
+                } else {
+                    [self.delegate cardTokenizationCompleted:tokenizedCard error:error sender:self];
+                }
             }
         });
     }];

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -45,15 +45,15 @@ PODS:
   - Braintree/Venmo (4.11.0):
     - Braintree/Core
     - Braintree/PayPalDataCollector
-  - BraintreeDropIn (6.0.1):
-    - BraintreeDropIn/DropIn (= 6.0.1)
-  - BraintreeDropIn/DropIn (6.0.1):
+  - BraintreeDropIn (6.1.0):
+    - BraintreeDropIn/DropIn (= 6.1.0)
+  - BraintreeDropIn/DropIn (6.1.0):
     - Braintree/Card (~> 4.11)
     - Braintree/Core (~> 4.11)
     - Braintree/PaymentFlow (~> 4.11)
     - Braintree/UnionPay (~> 4.11)
     - BraintreeDropIn/UIKit
-  - BraintreeDropIn/UIKit (6.0.1)
+  - BraintreeDropIn/UIKit (6.1.0)
   - CardIO (5.4.1)
   - Expecta (1.0.6)
   - FLEX (2.4.0)
@@ -101,7 +101,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
   Braintree: f52744f38d1f5f37f8719f7acee4e1d7a3acb758
-  BraintreeDropIn: 4cb63a9a8e85e3623688fd34841733aa67faf7e2
+  BraintreeDropIn: bcbf2cedd71e271b970afd4dbfab51d9476fc946
   CardIO: 56983b39b62f495fc6dae9ad7cf875143df06443
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   FLEX: bd1a39e55b56bb413b6f1b34b3c10a0dc44ef079

--- a/UITests/BraintreeDropIn_UITests.swift
+++ b/UITests/BraintreeDropIn_UITests.swift
@@ -99,6 +99,57 @@ class BraintreeDropIn_TokenizationKey_CardForm_UITests: XCTestCase {
     }
 }
 
+class BraintreeDropIn_securityCodeValidation_CardForm_UITests: XCTestCase {
+
+    var app: XCUIApplication!
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchArguments.append("-EnvironmentSandbox")
+        app.launchArguments.append("-ThreeDSecureDefault")
+        app.launchArguments.append("-Integration:BraintreeDemoDropInViewController")
+        // NOTE: This sandbox client token has CVV validation enabled.
+        app.launchArguments.append("-Authorization:eyJ2ZXJzaW9uIjoyLCJhdXRob3JpemF0aW9uRmluZ2VycHJpbnQiOiI2ZGE5Y2VhMzVkNGNlMjkxNGI3YzBiOGRiN2M5OWU4MjVmYTQ5ZTY5OTNiYWM4YmE3MTQwYjdiZjI0ODc4NGQ0fGNyZWF0ZWRfYXQ9MjAxOC0wMy0xMlQyMTo0MzoxMS4wOTI1MzAxNDcrMDAwMCZjdXN0b21lcl9pZD01ODA3NDE3NzEmbWVyY2hhbnRfaWQ9aGg0Y3BjMzl6cTRyZ2pjZyZwdWJsaWNfa2V5PXEzanRzcTNkM3Aycmg1dnQiLCJjb25maWdVcmwiOiJodHRwczovL2FwaS5zYW5kYm94LmJyYWludHJlZWdhdGV3YXkuY29tOjQ0My9tZXJjaGFudHMvaGg0Y3BjMzl6cTRyZ2pjZy9jbGllbnRfYXBpL3YxL2NvbmZpZ3VyYXRpb24iLCJncmFwaFFMVXJsIjoiaHR0cHM6Ly9wYXltZW50cy5zYW5kYm94LmJyYWludHJlZS1hcGkuY29tL2dyYXBocWwiLCJjaGFsbGVuZ2VzIjpbImN2diJdLCJlbnZpcm9ubWVudCI6InNhbmRib3giLCJjbGllbnRBcGlVcmwiOiJodHRwczovL2FwaS5zYW5kYm94LmJyYWludHJlZWdhdGV3YXkuY29tOjQ0My9tZXJjaGFudHMvaGg0Y3BjMzl6cTRyZ2pjZy9jbGllbnRfYXBpIiwiYXNzZXRzVXJsIjoiaHR0cHM6Ly9hc3NldHMuYnJhaW50cmVlZ2F0ZXdheS5jb20iLCJhdXRoVXJsIjoiaHR0cHM6Ly9hdXRoLnZlbm1vLnNhbmRib3guYnJhaW50cmVlZ2F0ZXdheS5jb20iLCJhbmFseXRpY3MiOnsidXJsIjoiaHR0cHM6Ly9jbGllbnQtYW5hbHl0aWNzLnNhbmRib3guYnJhaW50cmVlZ2F0ZXdheS5jb20vaGg0Y3BjMzl6cTRyZ2pjZyJ9LCJ0aHJlZURTZWN1cmVFbmFibGVkIjp0cnVlLCJwYXlwYWxFbmFibGVkIjp0cnVlLCJwYXlwYWwiOnsiZGlzcGxheU5hbWUiOiJidCIsImNsaWVudElkIjoiQVZRSmY5YS1iNmptWUZnaW9OcEkyaTU3cnNRa0hqUlpadjRkOURaTFRVMG5CU3Vma2h3QUNBWnhqMGxkdTg1amFzTTAyakZSUEthVElOQ04iLCJwcml2YWN5VXJsIjoiaHR0cDovL2V4YW1wbGUuY29tL3BwIiwidXNlckFncmVlbWVudFVybCI6Imh0dHA6Ly9leGFtcGxlLmNvbS90b3MiLCJiYXNlVXJsIjoiaHR0cHM6Ly9hc3NldHMuYnJhaW50cmVlZ2F0ZXdheS5jb20iLCJhc3NldHNVcmwiOiJodHRwczovL2NoZWNrb3V0LnBheXBhbC5jb20iLCJkaXJlY3RCYXNlVXJsIjpudWxsLCJhbGxvd0h0dHAiOnRydWUsImVudmlyb25tZW50Tm9OZXR3b3JrIjpmYWxzZSwiZW52aXJvbm1lbnQiOiJvZmZsaW5lIiwidW52ZXR0ZWRNZXJjaGFudCI6ZmFsc2UsImJyYWludHJlZUNsaWVudElkIjoibWFzdGVyY2xpZW50MyIsImJpbGxpbmdBZ3JlZW1lbnRzRW5hYmxlZCI6dHJ1ZSwibWVyY2hhbnRBY2NvdW50SWQiOiJjNXljdzJzdnlrbnp3anR6IiwiY3VycmVuY3lJc29Db2RlIjoiVVNEIn0sIm1lcmNoYW50SWQiOiJoaDRjcGMzOXpxNHJnamNnIiwidmVubW8iOiJvZmYiLCJicmFpbnRyZWVfYXBpIjp7InVybCI6Imh0dHBzOi8vcGF5bWVudHMuc2FuZGJveC5icmFpbnRyZWUtYXBpLmNvbSIsImFjY2Vzc190b2tlbiI6InNhbmRib3hfNmRkdG13X3B6YjZ3cF93ZHdoY3lfOWhnNm5iX2N5NiJ9fQ==")
+        app.launch()
+        sleep(1)
+        self.waitForElementToBeHittable(app.buttons["Change Payment Method"])
+        app.buttons["Change Payment Method"].tap()
+    }
+
+    func testDropIn_invalidSecurityCode_presentsAlert() {
+        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        app.staticTexts["Credit or Debit Card"].tap()
+
+        let elementsQuery = app.scrollViews.otherElements
+        let cardNumberTextField = elementsQuery.textFields["Card Number"]
+
+        self.waitForElementToBeHittable(cardNumberTextField)
+        cardNumberTextField.typeText("4000000000000002")
+
+        self.waitForElementToBeHittable(app.staticTexts["2019"])
+        app.staticTexts["11"].forceTapElement()
+        app.staticTexts["2019"].forceTapElement()
+
+        let securityCodeField = elementsQuery.textFields["CVV"]
+        self.waitForElementToBeHittable(securityCodeField)
+        securityCodeField.forceTapElement()
+        securityCodeField.typeText("200")
+
+        app.buttons["Add Card"].forceTapElement()
+
+        self.waitForElementToBeHittable(app.alerts.buttons["OK"])
+        XCTAssertTrue(app.alerts.staticTexts["Please review your information and try again."].exists);
+        app.alerts.buttons["OK"].tap()
+
+        // Assert: can edit after dismissing alert
+        self.waitForElementToBeHittable(securityCodeField)
+        securityCodeField.forceTapElement()
+        securityCodeField.typeText("\u{8}1")
+    }
+}
+
 class BraintreeDropIn_CardForm_RequestOptions_UITests: XCTestCase {
 
     var app: XCUIApplication!


### PR DESCRIPTION
Fix for https://github.com/braintree/braintree-ios-drop-in/issues/84

Current behavior: When CVV/AVS verification is enabled and an error is returned on tokenization - the error is returned via the Drop-in callback and the user is not able to retry. This is divergent from the web and Android experiences where the user is alerted of the issue and prompted to retry.

New behavior: An alert is shown when tokenization fails, prompting the user to `Please review your information and try again.` After dismissing the alert they are returned to the card form.