### PR TITLE
Dismiss postal address keyboard on return

### DIFF
--- a/BraintreeUIKit/Components/BTUIKPostalCodeFormField.m
+++ b/BraintreeUIKit/Components/BTUIKPostalCodeFormField.m
@@ -14,7 +14,7 @@
         self.formLabel.text = BTUIKLocalizedString(POSTAL_CODE_PLACEHOLDER);
         self.textField.placeholder = @"12345";
         self.textField.keyboardType = [BTUIKAppearance sharedInstance].postalCodeFormFieldKeyboardType;
-        
+
         self.textField.autocorrectionType = UITextAutocorrectionTypeNo;
         self.textField.autocapitalizationType = UITextAutocapitalizationTypeNone;
         self.textField.returnKeyType = UIReturnKeyDone;
@@ -49,6 +49,11 @@
 - (void)textFieldDidEndEditing:(UITextField *)textField {
     self.displayAsValid = YES;
     [super textFieldDidEndEditing:textField];
+}
+
+- (BOOL)textFieldShouldReturn:(UITextField *)textField {
+    [textField resignFirstResponder];
+    return YES;
 }
 
 @end


### PR DESCRIPTION
Fix for https://github.com/braintree/braintree-ios-drop-in/issues/105