### PR TITLE
Remove custom type for postcode field - Fixes #112

### DIFF
--- a/BraintreeUIKit/Components/BTUIKPostalCodeFormField.m
+++ b/BraintreeUIKit/Components/BTUIKPostalCodeFormField.m
@@ -13,7 +13,6 @@
         self.textField.accessibilityLabel = BTUIKLocalizedString(POSTAL_CODE_PLACEHOLDER);
         self.formLabel.text = BTUIKLocalizedString(POSTAL_CODE_PLACEHOLDER);
         self.textField.placeholder = @"12345";
-        self.textField.keyboardType = [BTUIKAppearance sharedInstance].postalCodeFormFieldKeyboardType;
 
         self.textField.autocorrectionType = UITextAutocorrectionTypeNo;
         self.textField.autocapitalizationType = UITextAutocapitalizationTypeNone;

--- a/BraintreeUIKit/Helpers/BTUIKAppearance.m
+++ b/BraintreeUIKit/Helpers/BTUIKAppearance.m
@@ -32,7 +32,6 @@ static BTUIKAppearance *sharedTheme;
     sharedTheme.blurStyle = UIBlurEffectStyleExtraLight;
     sharedTheme.activityIndicatorViewStyle = UIActivityIndicatorViewStyleGray;
     sharedTheme.useBlurs = YES;
-    sharedTheme.postalCodeFormFieldKeyboardType = UIKeyboardTypeNumberPad;
 }
 
 + (void)darkTheme {
@@ -52,7 +51,6 @@ static BTUIKAppearance *sharedTheme;
     sharedTheme.blurStyle = UIBlurEffectStyleDark;
     sharedTheme.activityIndicatorViewStyle = UIActivityIndicatorViewStyleWhite;
     sharedTheme.useBlurs = YES;
-    sharedTheme.postalCodeFormFieldKeyboardType = UIKeyboardTypeNumberPad;
 }
 
 - (UIColor *)highlightedTintColor {

--- a/BraintreeUIKit/Public/BTUIKAppearance.h
+++ b/BraintreeUIKit/Public/BTUIKAppearance.h
@@ -43,8 +43,6 @@
 @property (nonatomic) UIActivityIndicatorViewStyle activityIndicatorViewStyle;
 /// Toggle blur effects
 @property (nonatomic) BOOL useBlurs;
-/// The keyboard the postal code field should use
-@property (nonatomic) UIKeyboardType postalCodeFormFieldKeyboardType;
 /// The highlighted version of the `tintColor`
 @property (nonatomic, readonly, getter = highlightedTintColor) UIColor *highlightedTintColor;
 


### PR DESCRIPTION
Without UIKeyboardTypeNumberPad, the type will fall back to the default UIKeyboardTypeDefault which is more appropriate for postcodes.

| **Before**  | **After**  |
|---|---|
| <img width="300" src="https://user-images.githubusercontent.com/5849587/42768046-62b92288-8916-11e8-9609-541668338790.png">  | <img src="https://user-images.githubusercontent.com/5849587/42768066-70ac77b4-8916-11e8-96ae-0f617f3830c1.png" width="300"> |