### PR TITLE
Check for ApplePay capability before displaying it as a payment method - Fixes #118

### DIFF
--- a/BraintreeDropIn/BTPaymentSelectionViewController.m
+++ b/BraintreeDropIn/BTPaymentSelectionViewController.m
@@ -235,7 +235,7 @@
 
 #ifdef __BT_APPLE_PAY
             BTJSON *applePayConfiguration = self.configuration.json[@"applePay"];
-            if ([applePayConfiguration[@"status"] isString] && ![[applePayConfiguration[@"status"] asString] isEqualToString:@"off"] && !self.dropInRequest.applePayDisabled) {
+            if ([applePayConfiguration[@"status"] isString] && ![[applePayConfiguration[@"status"] asString] isEqualToString:@"off"] && !self.dropInRequest.applePayDisabled && self.configuration.canMakeApplePayPayments) {
                 // Short-circuits if BraintreeApplePay is not available at runtime
                 if (__BT_AVAILABLE(@"BTApplePayClient")) {
                     [activePaymentOptions addObject:@(BTUIKPaymentOptionTypeApplePay)];


### PR DESCRIPTION
If the device is not able to make payments using the supported networks configured in the Control Panel, the Apple Pay button is not displayed.

Check **https://github.com/braintree/braintree-ios-drop-in/issues/118** for details.

| Simulator with Wallet capability  | Device with Wallet not configured  |
|---|---|
| <img src="https://user-images.githubusercontent.com/5849587/44785950-84ffe700-ab8a-11e8-8f78-e49f01b3335b.png" width="300"> | <img src="https://user-images.githubusercontent.com/5849587/44785976-92b56c80-ab8a-11e8-9361-8786567cbc89.PNG" width="300">  |