### PR TITLE
luhn validate unionpay cards

### DIFF
--- a/BraintreeUIKit/Models/BTUIKCardType.m
+++ b/BraintreeUIKit/Models/BTUIKCardType.m
@@ -246,13 +246,11 @@
 #pragma mark - Validation
 
 - (BOOL)validAndNecessarilyCompleteNumber:(NSString *)number {
-    return (number.length == self.validNumberLengths.lastIndex &&
-            ([BTUIKUtil luhnValid:number] || [self.brand isEqualToString:BTUIKLocalizedString(CARD_TYPE_UNION_PAY)]));
+    return (number.length == self.validNumberLengths.lastIndex && [BTUIKUtil luhnValid:number]);
 }
 
 - (BOOL)validNumber:(NSString *)number {
-    return ([self completeNumber:number] &&
-            ([BTUIKUtil luhnValid:number] || [self.brand isEqualToString:BTUIKLocalizedString(CARD_TYPE_UNION_PAY)]));
+    return ([self completeNumber:number] && [BTUIKUtil luhnValid:number]);
 }
 
 - (BOOL)completeNumber:(NSString *)number {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS Drop-in SDK - Release Notes
 
+## Unreleased
+
+* Luhn validate UnionPay cards
+
 ## 6.4.1 (2018-08-20)
 
 * Improve detection of Maestro card numbers


### PR DESCRIPTION
UnionPay cards used to be issued with luhn invalid card numbers. We have always rejected luhn invalid cards on the backend, so this just brings the front end in line with that behavior.

@braintree/team-dx 