### PR TITLE
Changed from using current calendar (default) to gregorian calendar f…

### DIFF
--- a/BraintreeUIKit/Components/BTUIKExpiryInputView.m
+++ b/BraintreeUIKit/Components/BTUIKExpiryInputView.m
@@ -30,7 +30,7 @@
         self.months = @[@"01", @"02", @"03", @"04", @"05", @"06", @"07", @"08", @"09", @"10", @"11", @"12"];
         
         NSDate *currentDate = [NSDate date];
-        NSCalendar* calendar = [NSCalendar currentCalendar];
+        NSCalendar* calendar = [NSCalendar calendarWithIdentifier: NSCalendarIdentifierGregorian];
         NSDateComponents* components = [calendar components:NSCalendarUnitYear|NSCalendarUnitMonth fromDate:currentDate];
         
         self.currentYear = [components year];


### PR DESCRIPTION
…or date input

This fixes an issue with the drop in where if a user has the Buddhist calendar selected, it would present Buddhist years.  Credit cards are always issued with Gregorian years.