### PR TITLE
Fix #122 - Check for card tokenization errors also when 3DS is enabled

### DIFF
--- a/BraintreeDropIn/BTCardFormViewController.m
+++ b/BraintreeDropIn/BTCardFormViewController.m
@@ -617,35 +617,35 @@
 
             self.navigationItem.rightBarButtonItem = addCardButton;
 
-            if (self.dropInRequest.threeDSecureVerification && self.dropInRequest.amount != nil
-                && [self.configuration.json[@"threeDSecureEnabled"] isTrue]) {
-
-                BTPaymentFlowDriver *paymentFlowDriver = [[BTPaymentFlowDriver alloc] initWithAPIClient:self.apiClient];
-                paymentFlowDriver.viewControllerPresentingDelegate = self;
-
-                BTThreeDSecureRequest *request = [[BTThreeDSecureRequest alloc] init];
-                request.amount = [[NSDecimalNumber alloc] initWithString:self.dropInRequest.amount];
-                request.nonce = tokenizedCard.nonce;
-                [paymentFlowDriver startPaymentFlow:request completion:^(BTPaymentFlowResult * _Nonnull result, NSError * _Nonnull error) {
-                    if (error) {
-                        if (error.code == BTPaymentFlowDriverErrorTypeCanceled) {
-                            [self cancelTapped];
-                        } else {
-                            [self.delegate cardTokenizationCompleted:nil error:error sender:self];
-                        }
-                    } else if (result) {
-                        BTThreeDSecureResult *threeDSecureResult = (BTThreeDSecureResult *)result;
-                        [self.delegate cardTokenizationCompleted:threeDSecureResult.tokenizedCard error:error sender:self];
-                    }
-                }];
+            if (error != nil) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:BTUIKLocalizedString(CARD_DETAILS_LABEL) message:BTUIKLocalizedString(REVIEW_AND_TRY_AGAIN) preferredStyle:UIAlertControllerStyleAlert];
+                    UIAlertAction *alertAction = [UIAlertAction actionWithTitle:BTUIKLocalizedString(TOP_LEVEL_ERROR_ALERT_VIEW_OK_BUTTON_TEXT) style:UIAlertActionStyleDefault handler:nil];
+                    [alertController addAction: alertAction];
+                    [navController presentViewController:alertController animated:YES completion:nil];
+                });
             } else {
-                if (error != nil) {
-                    dispatch_async(dispatch_get_main_queue(), ^{
-                        UIAlertController *alertController = [UIAlertController alertControllerWithTitle:BTUIKLocalizedString(CARD_DETAILS_LABEL) message:BTUIKLocalizedString(REVIEW_AND_TRY_AGAIN) preferredStyle:UIAlertControllerStyleAlert];
-                        UIAlertAction *alertAction = [UIAlertAction actionWithTitle:BTUIKLocalizedString(TOP_LEVEL_ERROR_ALERT_VIEW_OK_BUTTON_TEXT) style:UIAlertActionStyleDefault handler:nil];
-                        [alertController addAction: alertAction];
-                        [navController presentViewController:alertController animated:YES completion:nil];
-                    });
+                if (self.dropInRequest.threeDSecureVerification && self.dropInRequest.amount != nil
+                    && [self.configuration.json[@"threeDSecureEnabled"] isTrue]) {
+
+                    BTPaymentFlowDriver *paymentFlowDriver = [[BTPaymentFlowDriver alloc] initWithAPIClient:self.apiClient];
+                    paymentFlowDriver.viewControllerPresentingDelegate = self;
+
+                    BTThreeDSecureRequest *request = [[BTThreeDSecureRequest alloc] init];
+                    request.amount = [[NSDecimalNumber alloc] initWithString:self.dropInRequest.amount];
+                    request.nonce = tokenizedCard.nonce;
+                    [paymentFlowDriver startPaymentFlow:request completion:^(BTPaymentFlowResult * _Nonnull result, NSError * _Nonnull error) {
+                        if (error) {
+                            if (error.code == BTPaymentFlowDriverErrorTypeCanceled) {
+                                [self cancelTapped];
+                            } else {
+                                [self.delegate cardTokenizationCompleted:nil error:error sender:self];
+                            }
+                        } else if (result) {
+                            BTThreeDSecureResult *threeDSecureResult = (BTThreeDSecureResult *)result;
+                            [self.delegate cardTokenizationCompleted:threeDSecureResult.tokenizedCard error:error sender:self];
+                        }
+                    }];
                 } else {
                     [self.delegate cardTokenizationCompleted:tokenizedCard error:error sender:self];
                 }


### PR DESCRIPTION
When 3DS is enabled, the completion callback of:
```objective-c
- (void)tokenizeCard:(nonnull BTCardRequest *)request
             options:(nullable NSDictionary *)options
          completion:(nonnull void (^)(BTCardNonce *_Nullable __strong, NSError *_Nullable __strong))completion;
```
doesn't check for errors.

Because of this, the `BTPaymentFlowDriver` starts the payment flow even if an error was returned:
```objective-c
- (void)startPaymentFlow:(nonnull BTPaymentFlowRequest<BTPaymentFlowRequestDelegate> *)request
              completion:(nonnull void (^)(BTPaymentFlowResult *_Nullable __strong, NSError *_Nullable __strong))completionBlock;
```

Triggering the following request:
```
https://api.sandbox.braintreegateway.com:443/merchants/[merchant_id]/client_api/v1/payment_methods/(null)/three_d_secure/lookup
                                                                                                   ^^^^^^
```
Which is 404'ing.

Using an invalid card number that triggers a 422 error results in this undefined behavior:

<img src="https://user-images.githubusercontent.com/5849587/51126469-1bbc0000-181b-11e9-8634-52eb9ba0022c.gif" width="230">

By checking for error earlier in the flow, we catch all cases, and the SDK behaves correctly:

<img src="https://user-images.githubusercontent.com/5849587/51127636-d77e2f00-181d-11e9-9918-5738c080227e.gif" width="230">
