### PR TITLE
Fix modular imports that are failing when using split projects

### DIFF
--- a/BraintreeDropIn/BTAPIClient_Internal_Category.h
+++ b/BraintreeDropIn/BTAPIClient_Internal_Category.h
@@ -1,7 +1,7 @@
 #if __has_include("BraintreeCore.h")
 #import "BraintreeCore.h"
 #else
-#import <BraintreeCore/BraintreeCore.h>
+#import <Braintree/BraintreeCore.h>
 #endif
 
 NS_ASSUME_NONNULL_BEGIN

--- a/BraintreeDropIn/BTCardFormViewController.m
+++ b/BraintreeDropIn/BTCardFormViewController.m
@@ -5,7 +5,7 @@
 #if __has_include("BraintreeCore.h")
 #import "BraintreeCore.h"
 #else
-#import <BraintreeCore/BraintreeCore.h>
+#import <Braintree/BraintreeCore.h>
 #endif
 #import "BTAPIClient_Internal_Category.h"
 #import "BTUIKBarButtonItem_Internal_Declaration.h"
@@ -14,17 +14,17 @@
 #if __has_include("BraintreeCard.h")
 #import "BraintreeCard.h"
 #else
-#import <BraintreeCard/BraintreeCard.h>
+#import <Braintree/BraintreeCard.h>
 #endif
 #if __has_include("BraintreeUnionPay.h")
 #import "BraintreeUnionPay.h"
 #else
-#import <BraintreeUnionPay/BraintreeUnionPay.h>
+#import <Braintree/BraintreeUnionPay.h>
 #endif
 #if __has_include("BraintreePaymentFlow.h")
 #import "BraintreePaymentFlow.h"
 #else
-#import <BraintreePaymentFlow/BraintreePaymentFlow.h>
+#import <Braintree/BraintreePaymentFlow.h>
 #endif
 
 @interface BTCardFormViewController () <BTViewControllerPresentingDelegate>

--- a/BraintreeDropIn/BTDropInController.m
+++ b/BraintreeDropIn/BTDropInController.m
@@ -6,14 +6,14 @@
 #if __has_include("BraintreeCore.h")
 #import "BraintreeCore.h"
 #else
-#import <BraintreeCore/BraintreeCore.h>
+#import <Braintree/BraintreeCore.h>
 #endif
 #if __has_include("BraintreeCard.h")
 #import "BraintreeCard.h"
 #import "BraintreeUnionPay.h"
 #else
-#import <BraintreeCard/BraintreeCard.h>
-#import <BraintreeUnionPay/BraintreeUnionPay.h>
+#import <Braintree/BraintreeCard.h>
+#import <Braintree/BraintreeUnionPay.h>
 #endif
 
 #define BT_ANIMATION_SLIDE_SPEED 0.35

--- a/BraintreeDropIn/BTPaymentSelectionViewController.m
+++ b/BraintreeDropIn/BTPaymentSelectionViewController.m
@@ -15,21 +15,21 @@
 #if __has_include("BraintreeCard.h")
 #import "BraintreeCard.h"
 #else
-#import <BraintreeCard/BraintreeCard.h>
+#import <Braintree/BraintreeCard.h>
 #endif
 
 #if __has_include("BraintreePayPal.h")
 #import "BraintreePayPal.h"
 #else
-#import <BraintreePayPal/BraintreePayPal.h>
+#import <Braintree/BraintreePayPal.h>
 #endif
 
 #if __has_include("BraintreeApplePay.h")
 #define __BT_APPLE_PAY
 #import "BraintreeApplePay.h"
-#elif __has_include(<BraintreeApplePay/BraintreeApplePay.h>)
+#elif __has_include(<Braintree/BraintreeApplePay.h>)
 #define __BT_APPLE_PAY
-#import <BraintreeApplePay/BraintreeApplePay.h>
+#import <Braintree/BraintreeApplePay.h>
 #endif
 
 #define SAVED_PAYMENT_METHODS_COLLECTION_SPACING 6

--- a/BraintreeDropIn/BTVaultManagementViewController.m
+++ b/BraintreeDropIn/BTVaultManagementViewController.m
@@ -5,12 +5,12 @@
 #if __has_include("BraintreeCore.h")
 #import "BraintreeCore.h"
 #else
-#import <BraintreeCore/BraintreeCore.h>
+#import <Braintree/BraintreeCore.h>
 #endif
 #if __has_include("BraintreeCard.h")
 #import "BraintreeCard.h"
 #else
-#import <BraintreeCard/BraintreeCard.h>
+#import <Braintree/BraintreeCard.h>
 #endif
 
 @interface BTVaultManagementViewController ()

--- a/BraintreeDropIn/Custom Views/BTUIPaymentMethodCollectionViewCell.h
+++ b/BraintreeDropIn/Custom Views/BTUIPaymentMethodCollectionViewCell.h
@@ -3,7 +3,7 @@
 #if __has_include("BTPaymentMethodNonce.h")
 #import "BTPaymentMethodNonce.h"
 #else
-#import <BraintreeCore/BTPaymentMethodNonce.h>
+#import <Braintree/BTPaymentMethodNonce.h>
 #endif
 
 @class BTUIKPaymentOptionCardView;

--- a/BraintreeDropIn/Models/BTDropInRequest.m
+++ b/BraintreeDropIn/Models/BTDropInRequest.m
@@ -2,7 +2,7 @@
 #if __has_include("BraintreeCore.h")
 #import "BTPostalAddress.h"
 #else
-#import <BraintreeCore/BTPostalAddress.h>
+#import <Braintree/BTPostalAddress.h>
 #endif
 
 @implementation BTDropInRequest

--- a/BraintreeDropIn/Models/BTDropInResult.m
+++ b/BraintreeDropIn/Models/BTDropInResult.m
@@ -3,7 +3,7 @@
 #if __has_include("BraintreeCore.h")
 #import "BraintreeCore.h"
 #else
-#import <BraintreeCore/BraintreeCore.h>
+#import <Braintree/BraintreeCore.h>
 #endif
 #if __has_include("BraintreeUIKit.h")
 #import "BraintreeUIKit.h"


### PR DESCRIPTION
In CocoaPods 1.7.0, an option to use a separate project for each pod was introduced.

However, in this mode, the Braintree SDK modular imports are erroring because there is only one module, and it's named `Braintree`. This is how CP sets it up in the absence of a module map.

The PR fixes the modular imports in this module's files.