### PR TITLE
Customize Supported Cards shown on the BTCardFormViewController

### DIFF
--- a/BraintreeDropIn/BTDropInController.m
+++ b/BraintreeDropIn/BTDropInController.m
@@ -228,10 +228,20 @@
                 [self updateToolbarForViewController:self.paymentSelectionViewController];
                 
                 NSArray *supportedCardTypes = [configuration.json[@"creditCards"][@"supportedCardTypes"] asArray];
+              
+                // Optionally configure the supported cards to display
+                NSMutableArray *displayCardTypes = [NSMutableArray new];
+                for (NSNumber *cardTypeToDisplay in [_dropInRequest supportedCardsDisplayed]) {
+                    BTUIKPaymentOptionType displayType = (BTUIKPaymentOptionType) [cardTypeToDisplay integerValue];
+                    if (![displayCardTypes containsObject:@(displayType)] && displayType != BTUIKPaymentOptionTypeUnknown) {
+                        [displayCardTypes addObject:@(displayType)];
+                    }
+                }
+              
                 NSMutableArray *paymentOptionTypes = [NSMutableArray new];
                 for (NSString *supportedCardType in supportedCardTypes) {
                     BTUIKPaymentOptionType paymentOptionType = [BTUIKViewUtil paymentOptionTypeForPaymentInfoType:supportedCardType];
-                    if (paymentOptionType != BTUIKPaymentOptionTypeUnknown) {
+                    if (paymentOptionType != BTUIKPaymentOptionTypeUnknown && ([displayCardTypes count] == 0 || [displayCardTypes containsObject:@(paymentOptionType)])) {
                         [paymentOptionTypes addObject: @(paymentOptionType)];
                     }
                 }

--- a/BraintreeDropIn/BTDropInController.m
+++ b/BraintreeDropIn/BTDropInController.m
@@ -231,7 +231,7 @@
               
                 // Optionally configure the supported cards to display
                 NSMutableArray *displayCardTypes = [NSMutableArray new];
-                for (NSNumber *cardTypeToDisplay in [_dropInRequest supportedCardsDisplayed]) {
+                for (NSNumber *cardTypeToDisplay in [self.dropInRequest supportedCardsDisplayed]) {
                     BTUIKPaymentOptionType displayType = (BTUIKPaymentOptionType) [cardTypeToDisplay integerValue];
                     if (![displayCardTypes containsObject:@(displayType)] && displayType != BTUIKPaymentOptionTypeUnknown) {
                         [displayCardTypes addObject:@(displayType)];

--- a/BraintreeDropIn/Models/BTDropInRequest.m
+++ b/BraintreeDropIn/Models/BTDropInRequest.m
@@ -19,6 +19,7 @@
     request.cardholderNameSetting = self.cardholderNameSetting;
     request.shouldMaskSecurityCode = self.shouldMaskSecurityCode;
     request.vaultManager = self.vaultManager;
+    request.supportedCardsDisplayed = self.supportedCardsDisplayed;
     return request;
 }
 

--- a/BraintreeDropIn/Public/BTDropInRequest.h
+++ b/BraintreeDropIn/Public/BTDropInRequest.h
@@ -58,6 +58,9 @@ typedef NS_ENUM(NSInteger, BTFormFieldSetting) {
 /// Defaults to false.
 @property (nonatomic, assign) BOOL vaultManager;
 
+/// Optional: When populated, filters out the list of cards from the supportedCardTypes to only display specified cards on the BTCardFormViewController
+@property (nonatomic, readwrite, strong, nullable) NSMutableArray<NSNumber *> *supportedCardsDisplayed;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
I would like to suggest the feature of allowing the cards shown on the `BTCardFormViewController` in the DropIn UI to be customizable. We do not always want to show some providers since we are not able to support all the card companies and do not want to confuse the user by making it seem like we do.

The PR adds a settable array to configure as a filter (if not empty) of cards to show on the UI. I am open to feedback! My Objective-C is rusty.

With Swift, you would be able to do
```
let request = BTDropInRequest()
request.supportedCardsDisplayed = [BTUIPaymentOptionType.visa.rawValue, BTUIPaymentOptionType.masterCard.rawValue]
```

![Simulator Screen Shot - iPhone 5s - 2019-04-11 at 16 58 35](https://user-images.githubusercontent.com/19902149/55992699-2865be00-5c7b-11e9-8d09-bc7820da37e1.png)
