### PR TITLE
Skip payment selection screen if only one source specified

### DIFF
--- a/BraintreeDropIn/BTCardFormViewController.m
+++ b/BraintreeDropIn/BTCardFormViewController.m
@@ -467,6 +467,7 @@
 - (void)cancelTapped {
     [self hideKeyboard];
     [self.delegate reloadDropInData];
+    [self.delegate dismissDropInController];
     [self dismissViewControllerAnimated:YES completion:nil];
 }
 

--- a/BraintreeDropIn/BTDropInController.m
+++ b/BraintreeDropIn/BTDropInController.m
@@ -282,7 +282,7 @@
                 }
                 self.displayCardTypes = paymentOptionTypes;
                 
-                if (self.canSkipSelectionController && [_dropInRequest onlyCardEnabled] && [BTUIKAppearance sharedInstance].shouldSkipPaymentSelectionScreen) {
+                if (self.canSkipSelectionController && [self._dropInRequest onlyCardEnabled] && [BTUIKAppearance sharedInstance].shouldSkipPaymentSelectionScreen) {
                     dispatch_async(dispatch_get_main_queue(), ^{
                         [self showLoadingScreen:NO];
                         [self performSelector:@selector(showCardForm:) withObject:self];

--- a/BraintreeDropIn/BTDropInController.m
+++ b/BraintreeDropIn/BTDropInController.m
@@ -41,6 +41,9 @@
 @property (nonatomic, copy) NSArray *displayCardTypes;
 @property (nonatomic, strong) UIVisualEffectView *blurredContentBackgroundView;
 @property (nonatomic, copy, nullable) BTDropInControllerHandler handler;
+@property (nonatomic) BOOL canSkipSelectionController;
+@property (nonatomic, strong) UIActivityIndicatorView *activityIndicatorView;
+@property (nonatomic, strong) UIView *activityIndicatorWrapperView;
 
 @end
 
@@ -59,10 +62,17 @@
         if (!_apiClient || !_dropInRequest) {
             return nil;
         }
+        
+        self.canSkipSelectionController = ![_dropInRequest vaultManager] && [_dropInRequest onlyOnePaymentMethodEnabled];
+        
         if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad) {
-            self.modalPresentationStyle = UIModalPresentationFormSheet;
-            // Customize the iPad size...
-            // self.preferredContentSize = CGSizeMake(600, 400);
+            if (self.canSkipSelectionController && [_dropInRequest onlyCardEnabled] && [BTUIKAppearance sharedInstance].shouldSkipPaymentSelectionScreen) {
+                self.modalPresentationStyle = UIModalPresentationOverCurrentContext;
+            } else {
+                self.modalPresentationStyle = UIModalPresentationFormSheet;
+                // Customize the iPad size...
+                // self.preferredContentSize = CGSizeMake(600, 400);
+            }
         } else {
             self.transitioningDelegate = self;
             self.modalPresentationStyle = UIModalPresentationCustom;
@@ -83,6 +93,11 @@
     [self setUpViews];
     [self setUpChildViewControllers];
     [self setUpConstraints];
+    
+    if (self.canSkipSelectionController && [_dropInRequest onlyCardEnabled] && [BTUIKAppearance sharedInstance].shouldSkipPaymentSelectionScreen) {
+        [self setUpLoadingIndicator];
+        [self showLoadingScreen:YES];
+    }
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -165,6 +180,17 @@
     [self.contentView addSubview:self.blurredContentBackgroundView];
     [self.contentView sendSubviewToBack:self.blurredContentBackgroundView];
     
+    // potentially hide the contentView for the transition
+    if (self.canSkipSelectionController && [_dropInRequest onlyCardEnabled] && [BTUIKAppearance sharedInstance].shouldSkipPaymentSelectionScreen) {
+        if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad) {
+            // only done because of iPad presentation style
+            self.view.hidden = YES;
+            self.view.alpha = 0.0;
+        }
+        
+        self.contentView.hidden = YES;
+        self.contentView.alpha = 0.0;
+    }
 }
 
 - (void)setUpChildViewControllers {
@@ -218,6 +244,25 @@
     [self applyContentViewConstraints];
 }
 
+- (void)setUpLoadingIndicator {
+    self.activityIndicatorWrapperView = [[UIView alloc] init];
+    self.activityIndicatorWrapperView.backgroundColor = [UIColor clearColor];
+    self.activityIndicatorWrapperView.hidden = YES;
+    [self.view addSubview:self.activityIndicatorWrapperView];
+    self.activityIndicatorWrapperView.translatesAutoresizingMaskIntoConstraints = NO;
+    
+    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[activityWrapper]|" options:0 metrics:nil views:@{@"activityWrapper": self.activityIndicatorWrapperView}]];
+    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[activityWrapper]|" options:0 metrics:nil views:@{@"activityWrapper": self.activityIndicatorWrapperView}]];
+    
+    self.activityIndicatorView = [UIActivityIndicatorView new];
+    self.activityIndicatorView.translatesAutoresizingMaskIntoConstraints = NO;
+    self.activityIndicatorView.activityIndicatorViewStyle = [BTUIKAppearance sharedInstance].activityIndicatorViewStyle;
+    [self.activityIndicatorView startAnimating];
+    [self.activityIndicatorWrapperView addSubview:self.activityIndicatorView];
+    [self.activityIndicatorView.centerXAnchor constraintEqualToAnchor:self.activityIndicatorWrapperView.centerXAnchor].active = YES;
+    [self.activityIndicatorView.centerYAnchor constraintEqualToAnchor:self.activityIndicatorWrapperView.centerYAnchor].active = YES;
+}
+
 - (void)loadConfiguration {
     [self.apiClient fetchOrReturnRemoteConfiguration:^(BTConfiguration * _Nullable configuration, NSError * _Nullable error) {
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -236,6 +281,13 @@
                     }
                 }
                 self.displayCardTypes = paymentOptionTypes;
+                
+                if (self.canSkipSelectionController && [_dropInRequest onlyCardEnabled] && [BTUIKAppearance sharedInstance].shouldSkipPaymentSelectionScreen) {
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                        [self showLoadingScreen:NO];
+                        [self performSelector:@selector(showCardForm:) withObject:self];
+                    });
+                }
             } else {
                 if (self.handler) {
                     self.handler(self, nil, error);
@@ -243,6 +295,13 @@
             }
         });
     }];
+}
+
+- (void)showLoadingScreen:(BOOL)show {
+    if (show) {
+        [self.view bringSubviewToFront:self.activityIndicatorWrapperView];
+    }
+    self.activityIndicatorWrapperView.hidden = !show;
 }
 
 #pragma mark - View management and actions
@@ -484,6 +543,14 @@
         navController.modalPresentationStyle = UIModalPresentationOverCurrentContext;
     }
     [self presentViewController:navController animated:YES completion:nil];
+}
+
+- (void)dismissDropInController {
+    if (self.canSkipSelectionController && [_dropInRequest onlyCardEnabled] && [BTUIKAppearance sharedInstance].shouldSkipPaymentSelectionScreen) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self performSelector:@selector(cancelHit:) withObject:self];
+        });
+    }
 }
 
 #pragma mark UIViewControllerTransitioningDelegate

--- a/BraintreeDropIn/BTDropInController.m
+++ b/BraintreeDropIn/BTDropInController.m
@@ -282,7 +282,7 @@
                 }
                 self.displayCardTypes = paymentOptionTypes;
                 
-                if (self.canSkipSelectionController && [self._dropInRequest onlyCardEnabled] && [BTUIKAppearance sharedInstance].shouldSkipPaymentSelectionScreen) {
+                if (self.canSkipSelectionController && [self.dropInRequest onlyCardEnabled] && [BTUIKAppearance sharedInstance].shouldSkipPaymentSelectionScreen) {
                     dispatch_async(dispatch_get_main_queue(), ^{
                         [self showLoadingScreen:NO];
                         [self performSelector:@selector(showCardForm:) withObject:self];

--- a/BraintreeDropIn/Models/BTDropInRequest.m
+++ b/BraintreeDropIn/Models/BTDropInRequest.m
@@ -22,4 +22,14 @@
     return request;
 }
 
+- (BOOL)onlyOnePaymentMethodEnabled {
+    NSArray *paymentMethods = @[[NSNumber numberWithBool:self.paypalDisabled], [NSNumber numberWithBool:self.applePayDisabled], [NSNumber numberWithBool:self.venmoDisabled], [NSNumber numberWithBool:self.cardDisabled]];
+    NSCountedSet *counts = [[NSCountedSet alloc] initWithArray:paymentMethods];
+    return [counts countForObject:@NO] == 1;
+}
+
+- (BOOL)onlyCardEnabled {
+    return self.onlyOnePaymentMethodEnabled && !self.cardDisabled;
+}
+
 @end

--- a/BraintreeDropIn/Public/BTDropInController.h
+++ b/BraintreeDropIn/Public/BTDropInController.h
@@ -48,6 +48,9 @@ typedef void (^BTDropInControllerHandler)(BTDropInController * _Nonnull controll
 /// @param sender The sender requesting the view be changed.
 - (void)editPaymentMethods:(id)sender;
 
+/// Allows an implementing class to ask the BTDropInController to dismiss.
+- (void)dismissDropInController;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/BraintreeDropIn/Public/BTDropInRequest.h
+++ b/BraintreeDropIn/Public/BTDropInRequest.h
@@ -58,6 +58,13 @@ typedef NS_ENUM(NSInteger, BTFormFieldSetting) {
 /// Defaults to false.
 @property (nonatomic, assign) BOOL vaultManager;
 
+/// Checks for whether or not only one payment type is enabled on the request object.
+/// Returns YES if all but one payment method is disabled.
+-(BOOL) onlyOnePaymentMethodEnabled;
+
+/// Returns YES if the only payment method enabled is card.
+-(BOOL) onlyCardEnabled;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/BraintreeUIKit/Helpers/BTUIKAppearance.m
+++ b/BraintreeUIKit/Helpers/BTUIKAppearance.m
@@ -33,6 +33,7 @@ static BTUIKAppearance *sharedTheme;
     sharedTheme.activityIndicatorViewStyle = UIActivityIndicatorViewStyleGray;
     sharedTheme.useBlurs = YES;
     sharedTheme.postalCodeFormFieldKeyboardType = UIKeyboardTypeNumberPad;
+    sharedTheme.shouldSkipPaymentSelectionScreen = NO;
 }
 
 + (void)darkTheme {
@@ -53,6 +54,7 @@ static BTUIKAppearance *sharedTheme;
     sharedTheme.activityIndicatorViewStyle = UIActivityIndicatorViewStyleWhite;
     sharedTheme.useBlurs = YES;
     sharedTheme.postalCodeFormFieldKeyboardType = UIKeyboardTypeNumberPad;
+    sharedTheme.shouldSkipPaymentSelectionScreen = NO;
 }
 
 - (UIColor *)highlightedTintColor {

--- a/BraintreeUIKit/Public/BTUIKAppearance.h
+++ b/BraintreeUIKit/Public/BTUIKAppearance.h
@@ -47,6 +47,8 @@
 @property (nonatomic) UIKeyboardType postalCodeFormFieldKeyboardType;
 /// The highlighted version of the `tintColor`
 @property (nonatomic, readonly, getter = highlightedTintColor) UIColor *highlightedTintColor;
+/// Whether or not the BTDropInController should be able to skip the BTPaymentSelectionViewController and navigate directly to the appropriate form
+@property (nonatomic) BOOL shouldSkipPaymentSelectionScreen;
 
 /// Sets the color (primary or secondary) and font with family and size (large or small)
 /// These properties are on the [BTUIKAppearance sharedInstance]


### PR DESCRIPTION
I would like to suggest the feature of skipping the payment selection screen if only one payment method was specified in the `BTDropInRequest` and vaultManager was disabled.

I only implemented it for card, but have it setup so that it could be doable for PayPal, Venmo, etc.

The code checks the request for f only one payment method was enabled and vault was not enabled, and the `BTDropInController` checks that if this method is the card type, then alter the presentation (for iPads doesn't allow form sheet to show, for iPhones it will hide the payment popup and make the dim screen look like the loading screen while it loads the configurations) and directly present the `BTCardFormViewController`.

It then wires up the cancel of the `BTCardFormViewController` to also dismiss the initial `BTDropInController`.

I opted to make the enabling customization on top of the `BTUIKAppearance` class so that even if the conditions were met to skip payment selection, the shared appearance class would have to be set true as well

`BTUIKAppearance.sharedInstance()?.shouldSkipPaymentSelectionScreen = true`

As always, I am open to feedback! Thanks for looking!