### PR TITLE
Accessibility (Voice Over) Improvements

### DIFF
--- a/BraintreeDropIn/BTPaymentSelectionViewController.m
+++ b/BraintreeDropIn/BTPaymentSelectionViewController.m
@@ -371,6 +371,10 @@
     cell.descriptionLabel.attributedText = typeWithDescription;
     cell.titleLabel.text = [BTUIKViewUtil nameForPaymentMethodType:[BTUIKViewUtil paymentOptionTypeForPaymentInfoType:typeString]];
     cell.paymentOptionCardView.paymentOptionType = [BTUIKViewUtil paymentOptionTypeForPaymentInfoType:typeString];
+
+    cell.isAccessibilityElement = YES;
+    cell.accessibilityLabel = [NSString stringWithFormat:@"%@-%@", typeString, typeWithDescription.string];
+
     return cell;
 }
 

--- a/BraintreeDropIn/Custom Views/BTDropInPaymentSeletionCell.m
+++ b/BraintreeDropIn/Custom Views/BTDropInPaymentSeletionCell.m
@@ -51,6 +51,8 @@
         self.selectedBackgroundView = backgroundView;
         self.backgroundView = nil;
         [self applyConstraints];
+
+        self.accessibilityTraits = UIAccessibilityTraitButton;
     }
     return self;
 }

--- a/BraintreeUIKit/Components/BTUIKCardListLabel.m
+++ b/BraintreeUIKit/Components/BTUIKCardListLabel.m
@@ -23,8 +23,6 @@
         self.availablePaymentOptionAttachments = @[];
 
         self.availablePaymentOptions = @[];
-
-        self.accessibilityElementsHidden = YES;
     }
     return self;
 }
@@ -55,9 +53,9 @@
     BTUIKPaymentOptionCardView *hint = [BTUIKPaymentOptionCardView new];
     hint.frame = CGRectMake(0, 0, [BTUIKAppearance smallIconWidth], [BTUIKAppearance smallIconHeight]);
 
-    for(NSNumber *paymentType in self.availablePaymentOptions) {
+    for (NSUInteger i = 0; i < self.availablePaymentOptions.count; i++) {
         NSTextAttachment *composeAttachment = [NSTextAttachment new];
-        BTUIKPaymentOptionType paymentOption = ((NSNumber*)paymentType).intValue;
+        BTUIKPaymentOptionType paymentOption = ((NSNumber*)self.availablePaymentOptions[i]).intValue;
         hint.paymentOptionType = paymentOption;
         [hint setNeedsLayout];
         [hint layoutIfNeeded];
@@ -66,7 +64,8 @@
         [attachments addObject:composeAttachment];
         composeAttachment.image = composeImage;
         [at appendAttributedString:[NSAttributedString attributedStringWithAttachment:composeAttachment]];
-        [at appendAttributedString:[[NSMutableAttributedString alloc] initWithString:@" "]];
+        [at appendAttributedString:[[NSMutableAttributedString alloc]
+                                    initWithString: i < self.availablePaymentOptions.count - 1? @" " : @""]];
     }
     self.attributedText = at;
     self.availablePaymentOptionAttachments = attachments;
@@ -85,9 +84,15 @@
         UIGraphicsBeginImageContextWithOptions(attachment.image.size, NO, attachment.image.scale);
         [attachment.image drawAtPoint:CGPointZero blendMode:kCGBlendModeNormal alpha:newAlpha];
         UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
-        image.accessibilityLabel = [BTUIKViewUtil nameForPaymentMethodType:paymentOption];
         UIGraphicsEndImageContext();
         attachment.image = image;
+
+        // Update accessibility label for highlighted cards
+        if (paymentOption == option) {
+            image.accessibilityLabel = [BTUIKViewUtil nameForPaymentMethodType:paymentOption];
+        } else if (paymentOption == BTUIKPaymentOptionTypeUnknown) {
+            image.accessibilityLabel = [BTUIKViewUtil nameForPaymentMethodType:((NSNumber*)self.availablePaymentOptions[i]).intValue];
+        }
     }
     self.emphasisedPaymentOption = paymentOption;
     [self setNeedsDisplay];

--- a/BraintreeUIKit/Components/BTUIKCardListLabel.m
+++ b/BraintreeUIKit/Components/BTUIKCardListLabel.m
@@ -23,6 +23,8 @@
         self.availablePaymentOptionAttachments = @[];
 
         self.availablePaymentOptions = @[];
+
+        self.accessibilityElementsHidden = YES;
     }
     return self;
 }

--- a/BraintreeUIKit/Components/BTUIKExpiryFormField.m
+++ b/BraintreeUIKit/Components/BTUIKExpiryFormField.m
@@ -57,7 +57,6 @@
 - (void)updatePlaceholder {
     NSString *placeholder = BTUIKLocalizedString(EXPIRY_PLACEHOLDER_FOUR_DIGIT_YEAR);
     [self setThemedPlaceholder:placeholder];
-    self.textField.accessibilityLabel = placeholder;
 }
 
 - (void)kernExpiration:(NSMutableAttributedString *)input {

--- a/BraintreeUIKit/Components/BTUIKFormField.m
+++ b/BraintreeUIKit/Components/BTUIKFormField.m
@@ -37,6 +37,7 @@
         [BTUIKAppearance styleLabelBoldPrimary:self.formLabel];
         self.formLabel.translatesAutoresizingMaskIntoConstraints = NO;
         self.formLabel.text = @"";
+        self.formLabel.accessibilityElementsHidden = YES;
         [self addSubview:self.formLabel];
 
         [self.formLabel setContentHuggingPriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];


### PR DESCRIPTION
#### Summary
This PR enhances a few accessibility features in our drop-in UI related to voice over.

#### Changes
- Each available payment method was not reading off as an interactive button element on voice over. Added a button accessibility trait to each cell. *Example: Previously, the screen reader would read "Credit or Debit Card - static text" which now will read "Credit or Debit Card - button".*
- The list of available card icons was reading off erroneous values when a user started entering a card number, and then deleted it. That was fixed in addition to preventing the voice over from saying "space" after the last card type.
- On the add card form, removed voice over for field label names. Since the text fields themselves already read the label name, it was getting read twice. This also makes it more clear where user input is required.
- Voice over support was added to vaulted payment method cells. They are read off with their payment type followed by description. *Ex: "PayPal - email@me.com" and "Visa - •••11".*

#### Note
I would like to change "•••" to read as "ending in", but that would require translations and I felt this was a good start for now.