### PR TITLE
Fix iOS 13 Font Issues

### DIFF
--- a/BraintreeDropIn/BTDropInController.m
+++ b/BraintreeDropIn/BTDropInController.m
@@ -124,7 +124,10 @@
 #pragma mark - Setup
 
 - (void)setUpViews {
-    [[UIBarButtonItem appearanceWhenContainedInInstancesOfClasses:@[BTDropInController.self]] setTitleTextAttributes:@{NSForegroundColorAttributeName: [BTUIKAppearance sharedInstance].tintColor, NSFontAttributeName:[UIFont fontWithName:[BTUIKAppearance sharedInstance].fontFamily size:[UIFont labelFontSize]]} forState:UIControlStateNormal];
+    [[UIBarButtonItem appearanceWhenContainedInInstancesOfClasses:@[BTDropInController.self]]
+     setTitleTextAttributes:@{NSForegroundColorAttributeName:[BTUIKAppearance sharedInstance].tintColor,
+                              NSFontAttributeName:[[BTUIKAppearance sharedInstance].font fontWithSize:UIFont.labelFontSize]}
+     forState:UIControlStateNormal];
     if ([BTUIKAppearance sharedInstance].tintColor != nil) {
         self.view.tintColor = [BTUIKAppearance sharedInstance].tintColor;
     }

--- a/BraintreeDropIn/BTPaymentSelectionViewController.m
+++ b/BraintreeDropIn/BTPaymentSelectionViewController.m
@@ -134,11 +134,17 @@ static BOOL _vaultedCardAppearAnalyticSent = NO;
 
     self.vaultedPaymentsEditButton = [UIButton new];
     self.vaultedPaymentsEditButton.hidden = YES;
-    NSAttributedString *normalVaultedPaymentsEditButton = [[NSAttributedString alloc] initWithString:BTUIKLocalizedString(EDIT_ACTION) attributes:@{NSForegroundColorAttributeName:[BTUIKAppearance sharedInstance].tintColor, NSFontAttributeName:[UIFont fontWithName:[BTUIKAppearance sharedInstance].fontFamily size:[UIFont systemFontSize]]}];
+    NSAttributedString *normalVaultedPaymentsEditButton = [[NSAttributedString alloc] initWithString:BTUIKLocalizedString(EDIT_ACTION)
+                                                                                          attributes:@{NSForegroundColorAttributeName:[BTUIKAppearance sharedInstance].tintColor,
+                                                                                                       NSFontAttributeName:[[BTUIKAppearance sharedInstance].font fontWithSize:UIFont.systemFontSize]}];
     [self.vaultedPaymentsEditButton setAttributedTitle:normalVaultedPaymentsEditButton forState:UIControlStateNormal];
-    NSAttributedString *highlightVaultedPaymentsEditButton = [[NSAttributedString alloc] initWithString:BTUIKLocalizedString(EDIT_ACTION) attributes:@{NSForegroundColorAttributeName:[BTUIKAppearance sharedInstance].highlightedTintColor, NSFontAttributeName:[UIFont fontWithName:[BTUIKAppearance sharedInstance].fontFamily size:[UIFont systemFontSize]]}];
+    NSAttributedString *highlightVaultedPaymentsEditButton = [[NSAttributedString alloc] initWithString:BTUIKLocalizedString(EDIT_ACTION)
+                                                                                             attributes:@{NSForegroundColorAttributeName:[BTUIKAppearance sharedInstance].highlightedTintColor,
+                                                                                                          NSFontAttributeName:[[BTUIKAppearance sharedInstance].font fontWithSize:UIFont.systemFontSize]}];
     [self.vaultedPaymentsEditButton setAttributedTitle:highlightVaultedPaymentsEditButton forState:UIControlStateHighlighted];
-    NSAttributedString *disabledVaultedPaymentsEditButton = [[NSAttributedString alloc] initWithString:BTUIKLocalizedString(EDIT_ACTION) attributes:@{NSForegroundColorAttributeName:[BTUIKAppearance sharedInstance].disabledColor, NSFontAttributeName:[UIFont fontWithName:[BTUIKAppearance sharedInstance].fontFamily size:[UIFont systemFontSize]]}];
+    NSAttributedString *disabledVaultedPaymentsEditButton = [[NSAttributedString alloc] initWithString:BTUIKLocalizedString(EDIT_ACTION)
+                                                                                            attributes:@{NSForegroundColorAttributeName:[BTUIKAppearance sharedInstance].disabledColor,
+                                                                                                         NSFontAttributeName:[[BTUIKAppearance sharedInstance].font fontWithSize:UIFont.systemFontSize]}];
     [self.vaultedPaymentsEditButton setAttributedTitle:disabledVaultedPaymentsEditButton forState:UIControlStateDisabled];
     [self.vaultedPaymentsEditButton sizeToFit];
     [self.vaultedPaymentsEditButton layoutIfNeeded];

--- a/BraintreeDropIn/Custom Views/BTEnrollmentVerificationViewController.m
+++ b/BraintreeDropIn/Custom Views/BTEnrollmentVerificationViewController.m
@@ -66,9 +66,13 @@
     self.resendSmsButton.translatesAutoresizingMaskIntoConstraints = NO;
     [self.resendSmsButton setTitle:smsButtonText forState:UIControlStateNormal];
     
-    NSAttributedString *normalValidateButtonString = [[NSAttributedString alloc] initWithString:smsButtonText attributes:@{NSForegroundColorAttributeName:[BTUIKAppearance sharedInstance].tintColor, NSFontAttributeName:[UIFont fontWithName:[BTUIKAppearance sharedInstance].fontFamily size:[UIFont labelFontSize]]}];
+    NSAttributedString *normalValidateButtonString = [[NSAttributedString alloc] initWithString:smsButtonText
+                                                                                     attributes:@{NSForegroundColorAttributeName:[BTUIKAppearance sharedInstance].tintColor,
+                                                                                                  NSFontAttributeName:[[BTUIKAppearance sharedInstance].font fontWithSize:UIFont.labelFontSize]}];
     [self.resendSmsButton setAttributedTitle:normalValidateButtonString forState:UIControlStateNormal];
-    NSAttributedString *disabledValidateButtonString = [[NSAttributedString alloc] initWithString:smsButtonText attributes:@{NSForegroundColorAttributeName:[BTUIKAppearance sharedInstance].disabledColor, NSFontAttributeName:[UIFont fontWithName:[BTUIKAppearance sharedInstance].fontFamily size:[UIFont labelFontSize]]}];
+    NSAttributedString *disabledValidateButtonString = [[NSAttributedString alloc] initWithString:smsButtonText
+                                                                                       attributes:@{NSForegroundColorAttributeName:[BTUIKAppearance sharedInstance].disabledColor,
+                                                                                                    NSFontAttributeName:[[BTUIKAppearance sharedInstance].font fontWithSize:UIFont.labelFontSize]}];
     [self.resendSmsButton setAttributedTitle:disabledValidateButtonString forState:UIControlStateDisabled];
     
     [self.resendSmsButton sizeToFit];

--- a/BraintreeUIKit/Components/BTUIKBarButtonItem.m
+++ b/BraintreeUIKit/Components/BTUIKBarButtonItem.m
@@ -16,10 +16,24 @@
 }
 
 - (void)updateTitleTextAttributes {
-    NSString *fontName = self.bold ? [BTUIKAppearance sharedInstance].boldFontFamily : [BTUIKAppearance sharedInstance].fontFamily;
-    [self setTitleTextAttributes:@{NSForegroundColorAttributeName: [BTUIKAppearance sharedInstance].tintColor, NSFontAttributeName:[UIFont fontWithName:fontName size:[UIFont labelFontSize]]} forState:UIControlStateNormal];
-    [self setTitleTextAttributes:@{NSForegroundColorAttributeName: [BTUIKAppearance sharedInstance].tintColor, NSFontAttributeName:[UIFont fontWithName:fontName size:[UIFont labelFontSize]]} forState:UIControlStateNormal | UIControlStateHighlighted];
-    [self setTitleTextAttributes:@{NSForegroundColorAttributeName: [BTUIKAppearance sharedInstance].disabledColor, NSFontAttributeName:[UIFont fontWithName:fontName size:[UIFont labelFontSize]]} forState:UIControlStateDisabled];
+    UIFont *font;
+    if (self.bold) {
+        font = [[BTUIKAppearance sharedInstance].boldFont fontWithSize:UIFont.labelFontSize];
+    } else {
+        font = [[BTUIKAppearance sharedInstance].font fontWithSize:UIFont.labelFontSize];
+    }
+
+    [self setTitleTextAttributes:@{NSForegroundColorAttributeName: [BTUIKAppearance sharedInstance].tintColor,
+                                   NSFontAttributeName:font}
+                        forState:UIControlStateNormal];
+
+    [self setTitleTextAttributes:@{NSForegroundColorAttributeName: [BTUIKAppearance sharedInstance].tintColor,
+                                   NSFontAttributeName:font}
+                        forState:UIControlStateNormal | UIControlStateHighlighted];
+
+    [self setTitleTextAttributes:@{NSForegroundColorAttributeName: [BTUIKAppearance sharedInstance].disabledColor,
+                                   NSFontAttributeName:font}
+                        forState:UIControlStateDisabled];
 }
 
 @end

--- a/BraintreeUIKit/Components/BTUIKBarButtonItem.m
+++ b/BraintreeUIKit/Components/BTUIKBarButtonItem.m
@@ -25,10 +25,6 @@
 
     [self setTitleTextAttributes:@{NSForegroundColorAttributeName: [BTUIKAppearance sharedInstance].tintColor,
                                    NSFontAttributeName:font}
-                        forState:UIControlStateNormal];
-
-    [self setTitleTextAttributes:@{NSForegroundColorAttributeName: [BTUIKAppearance sharedInstance].tintColor,
-                                   NSFontAttributeName:font}
                         forState:UIControlStateNormal | UIControlStateHighlighted];
 
     [self setTitleTextAttributes:@{NSForegroundColorAttributeName: [BTUIKAppearance sharedInstance].disabledColor,

--- a/BraintreeUIKit/Components/BTUIKCardNumberFormField.m
+++ b/BraintreeUIKit/Components/BTUIKCardNumberFormField.m
@@ -41,9 +41,14 @@
         self.validateButton = [UIButton new];
         [self.validateButton setTitle:BTUIKLocalizedString(NEXT_ACTION) forState:UIControlStateNormal];
         
-        NSAttributedString *normalValidateButtonString = [[NSAttributedString alloc] initWithString:BTUIKLocalizedString(NEXT_ACTION) attributes:@{NSForegroundColorAttributeName:[BTUIKAppearance sharedInstance].tintColor, NSFontAttributeName:[UIFont fontWithName:[BTUIKAppearance sharedInstance].boldFontFamily size:[UIFont labelFontSize]]}];
-        [self.validateButton setAttributedTitle:normalValidateButtonString forState:UIControlStateNormal];
-        NSAttributedString *disabledValidateButtonString = [[NSAttributedString alloc] initWithString:BTUIKLocalizedString(NEXT_ACTION) attributes:@{NSForegroundColorAttributeName:[BTUIKAppearance sharedInstance].disabledColor, NSFontAttributeName:[UIFont fontWithName:[BTUIKAppearance sharedInstance].boldFontFamily size:[UIFont labelFontSize]]}];
+        NSAttributedString *normalValidateButtonString = [[NSAttributedString alloc] initWithString:BTUIKLocalizedString(NEXT_ACTION)
+                                                                                         attributes:@{NSForegroundColorAttributeName:[BTUIKAppearance sharedInstance].tintColor,
+                                                                                                      NSFontAttributeName:[[BTUIKAppearance sharedInstance].boldFont fontWithSize:UIFont.labelFontSize]}];
+        [self.validateButton setAttributedTitle:normalValidateButtonString
+                                       forState:UIControlStateNormal];
+        NSAttributedString *disabledValidateButtonString = [[NSAttributedString alloc] initWithString:BTUIKLocalizedString(NEXT_ACTION)
+                                                                                           attributes:@{NSForegroundColorAttributeName:[BTUIKAppearance sharedInstance].disabledColor,
+                                                                                                        NSFontAttributeName:[[BTUIKAppearance sharedInstance].boldFont fontWithSize:UIFont.labelFontSize]}];
         [self.validateButton setAttributedTitle:disabledValidateButtonString forState:UIControlStateDisabled];
 
         [self.validateButton sizeToFit];

--- a/BraintreeUIKit/Components/BTUIKCollectionReusableView.m
+++ b/BraintreeUIKit/Components/BTUIKCollectionReusableView.m
@@ -10,7 +10,7 @@
         self.label = [[UILabel alloc] init];
         self.label.translatesAutoresizingMaskIntoConstraints = NO;
         self.label.textAlignment = NSTextAlignmentCenter;
-        self.label.font = [UIFont fontWithName:[BTUIKAppearance sharedInstance].fontFamily size:12];
+        self.label.font = [[BTUIKAppearance sharedInstance].font fontWithSize:12];
         self.label.textColor = [BTUIKAppearance sharedInstance].secondaryTextColor;
         [self addSubview:self.label];
         

--- a/BraintreeUIKit/Components/BTUIKExpiryInputCollectionViewCell.m
+++ b/BraintreeUIKit/Components/BTUIKExpiryInputCollectionViewCell.m
@@ -9,7 +9,7 @@
     if (self) {
         self.label = [[UILabel alloc] init];
         self.backgroundColor = [BTUIKAppearance sharedInstance].formFieldBackgroundColor;
-        self.label.font = [UIFont fontWithName:[BTUIKAppearance sharedInstance].fontFamily size:24];
+        self.label.font = [[BTUIKAppearance sharedInstance].font fontWithSize:24];
         self.label.textColor = [BTUIKAppearance sharedInstance].primaryTextColor;
         self.label.translatesAutoresizingMaskIntoConstraints = NO;
         self.label.textAlignment = NSTextAlignmentCenter;

--- a/BraintreeUIKit/Components/BTUIKFormField.m
+++ b/BraintreeUIKit/Components/BTUIKFormField.m
@@ -201,7 +201,9 @@
     }
     
     NSMutableAttributedString *mutableText = [[NSMutableAttributedString alloc] initWithAttributedString:self.textField.attributedText];
-    [mutableText addAttributes:@{NSForegroundColorAttributeName: textColor, NSFontAttributeName:[UIFont fontWithName:[BTUIKAppearance sharedInstance].fontFamily size:[UIFont labelFontSize]]} range:NSMakeRange(0, mutableText.length)];
+    [mutableText addAttributes:@{NSForegroundColorAttributeName: textColor,
+                                 NSFontAttributeName:[[BTUIKAppearance sharedInstance].font fontWithSize:UIFont.labelFontSize]}
+                         range:NSMakeRange(0, mutableText.length)];
     
     UITextRange *currentRange = self.textField.selectedTextRange;
     

--- a/BraintreeUIKit/Components/BTUIKTextField.m
+++ b/BraintreeUIKit/Components/BTUIKTextField.m
@@ -23,7 +23,9 @@
 - (void)setPlaceholder:(NSString *)placeholder {
     NSMutableAttributedString *mutablePlaceholder = [[NSMutableAttributedString alloc] initWithString:placeholder];
     [mutablePlaceholder beginEditing];
-    [mutablePlaceholder addAttributes:@{NSForegroundColorAttributeName: [BTUIKAppearance sharedInstance].placeholderTextColor, NSFontAttributeName:[UIFont fontWithName:[BTUIKAppearance sharedInstance].fontFamily size:[UIFont labelFontSize]]} range:NSMakeRange(0, [mutablePlaceholder length])];
+    [mutablePlaceholder addAttributes:@{NSForegroundColorAttributeName: [BTUIKAppearance sharedInstance].placeholderTextColor,
+                                        NSFontAttributeName:[[BTUIKAppearance sharedInstance].font fontWithSize:UIFont.labelFontSize]}
+                                range:NSMakeRange(0, [mutablePlaceholder length])];
     [mutablePlaceholder endEditing];
     
     self.attributedPlaceholder = mutablePlaceholder;

--- a/BraintreeUIKit/Helpers/BTUIKAppearance.m
+++ b/BraintreeUIKit/Helpers/BTUIKAppearance.m
@@ -1,6 +1,13 @@
 #import "BTUIKAppearance.h"
 #import "UIColor+BTUIK.h"
 
+@interface BTUIKAppearance ()
+
+@property (nonatomic, strong) UIFont *font;
+@property (nonatomic, strong) UIFont *boldFont;
+
+@end
+
 @implementation BTUIKAppearance
 
 static BTUIKAppearance *sharedTheme;
@@ -59,19 +66,21 @@ static BTUIKAppearance *sharedTheme;
     sharedTheme.switchOnTintColor = UIColor.greenColor;
 }
 
-- (UIFont *)font {
-    if (_fontFamily) {
-        return [UIFont fontWithName:_fontFamily size:10.0];
+- (void)setFontFamily:(NSString *)fontFamily {
+    _fontFamily = fontFamily;
+    if (fontFamily != nil) {
+        _font = [UIFont fontWithName:fontFamily size:10.0];
     } else {
-        return _font;
+        _font = [UIFont systemFontOfSize:10.0];
     }
 }
 
-- (UIFont *)boldFont {
-    if (_boldFontFamily) {
-        return [UIFont fontWithName:_boldFontFamily size:10.0];
+- (void)setBoldFontFamily:(NSString *)boldFontFamily {
+    _boldFontFamily = boldFontFamily;
+    if (boldFontFamily != nil) {
+        _boldFont = [UIFont fontWithName:boldFontFamily size:10.0];
     } else {
-        return _boldFont;
+        _boldFont = [UIFont boldSystemFontOfSize:10.0];
     }
 }
 

--- a/BraintreeUIKit/Helpers/BTUIKAppearance.m
+++ b/BraintreeUIKit/Helpers/BTUIKAppearance.m
@@ -19,8 +19,8 @@ static BTUIKAppearance *sharedTheme;
     sharedTheme.overlayColor = [UIColor btuik_colorFromHex:@"000000" alpha:0.5];
     sharedTheme.tintColor = [UIColor btuik_colorFromHex:@"2489F6" alpha:1.0];
     sharedTheme.barBackgroundColor = UIColor.whiteColor;
-    sharedTheme.fontFamily = [UIFont systemFontOfSize:10].fontName;
-    sharedTheme.boldFontFamily = [UIFont boldSystemFontOfSize:10].fontName;
+    sharedTheme.font = [UIFont systemFontOfSize:10];
+    sharedTheme.boldFont = [UIFont boldSystemFontOfSize:10];
     sharedTheme.formBackgroundColor = UIColor.groupTableViewBackgroundColor;
     sharedTheme.formFieldBackgroundColor =  UIColor.whiteColor;
     sharedTheme.primaryTextColor = UIColor.blackColor;
@@ -41,8 +41,8 @@ static BTUIKAppearance *sharedTheme;
     sharedTheme.overlayColor = [UIColor btuik_colorFromHex:@"000000" alpha:0.5];
     sharedTheme.tintColor = [UIColor btuik_colorFromHex:@"2489F6" alpha:1.0];
     sharedTheme.barBackgroundColor = [UIColor btuik_colorFromHex:@"222222" alpha:1.0];
-    sharedTheme.fontFamily = [UIFont systemFontOfSize:10].fontName;
-    sharedTheme.boldFontFamily = [UIFont boldSystemFontOfSize:10].fontName;
+    sharedTheme.font = [UIFont systemFontOfSize:10];
+    sharedTheme.boldFont = [UIFont boldSystemFontOfSize:10];
     sharedTheme.formBackgroundColor = [UIColor btuik_colorFromHex:@"222222" alpha:1.0];
     sharedTheme.formFieldBackgroundColor = [UIColor btuik_colorFromHex:@"333333" alpha:1.0];
     sharedTheme.primaryTextColor =  UIColor.whiteColor;
@@ -59,42 +59,58 @@ static BTUIKAppearance *sharedTheme;
     sharedTheme.switchOnTintColor = UIColor.greenColor;
 }
 
+- (UIFont *)font {
+    if (_fontFamily) {
+        return [UIFont fontWithName:_fontFamily size:10.0];
+    } else {
+        return _font;
+    }
+}
+
+- (UIFont *)boldFont {
+    if (_boldFontFamily) {
+        return [UIFont fontWithName:_boldFontFamily size:10.0];
+    } else {
+        return _boldFont;
+    }
+}
+
 - (UIColor *)highlightedTintColor {
     return [sharedTheme.tintColor colorWithAlphaComponent:0.4];
 }
 
 + (void)styleLabelPrimary:(UILabel *)label {
-    label.font = [UIFont fontWithName:[BTUIKAppearance sharedInstance].fontFamily size:[UIFont labelFontSize]];
+    label.font = [[BTUIKAppearance sharedInstance].font fontWithSize:UIFont.labelFontSize];
     label.textColor = [BTUIKAppearance sharedInstance].primaryTextColor;
 }
 
 + (void)styleLabelBoldPrimary:(UILabel *)label {
-    label.font = [UIFont fontWithName:[BTUIKAppearance sharedInstance].boldFontFamily size:[UIFont labelFontSize]];
+    label.font = [[BTUIKAppearance sharedInstance].boldFont fontWithSize:UIFont.labelFontSize];
     label.textColor = [BTUIKAppearance sharedInstance].primaryTextColor;
 }
 
 + (void)styleSmallLabelBoldPrimary:(UILabel *)label {
-    label.font = [UIFont fontWithName:[BTUIKAppearance sharedInstance].boldFontFamily size:[UIFont smallSystemFontSize]];
+    label.font = [[BTUIKAppearance sharedInstance].boldFont fontWithSize:UIFont.smallSystemFontSize];
     label.textColor = [BTUIKAppearance sharedInstance].primaryTextColor;
 }
 
 + (void)styleSmallLabelPrimary:(UILabel *)label {
-    label.font = [UIFont fontWithName:[BTUIKAppearance sharedInstance].fontFamily size:[UIFont smallSystemFontSize]];
+    label.font = [[BTUIKAppearance sharedInstance].font fontWithSize:UIFont.smallSystemFontSize];
     label.textColor = [BTUIKAppearance sharedInstance].primaryTextColor;
 }
 
 + (void)styleLabelSecondary:(UILabel *)label {
-    label.font = [UIFont fontWithName:[BTUIKAppearance sharedInstance].fontFamily size:[UIFont smallSystemFontSize]];
+    label.font = [[BTUIKAppearance sharedInstance].font fontWithSize:UIFont.smallSystemFontSize];
     label.textColor = [BTUIKAppearance sharedInstance].secondaryTextColor;
 }
 
-+ (void) styleLargeLabelSecondary:(UILabel *)label {
-    label.font = [UIFont fontWithName:[BTUIKAppearance sharedInstance].fontFamily size:[UIFont labelFontSize]];
++ (void)styleLargeLabelSecondary:(UILabel *)label {
+    label.font = [[BTUIKAppearance sharedInstance].font fontWithSize:UIFont.labelFontSize];
     label.textColor = [BTUIKAppearance sharedInstance].secondaryTextColor;
 }
 
 + (void)styleSystemLabelSecondary:(UILabel *)label {
-    label.font = [UIFont fontWithName:[BTUIKAppearance sharedInstance].fontFamily size:[UIFont systemFontSize]];
+    label.font = [[BTUIKAppearance sharedInstance].font fontWithSize:UIFont.systemFontSize];
     label.textColor = [BTUIKAppearance sharedInstance].secondaryTextColor;
 }
 
@@ -102,7 +118,7 @@ static BTUIKAppearance *sharedTheme;
     UILabel *tlabel = [[UILabel alloc] initWithFrame:CGRectMake(0,0, 200, 40)];
     tlabel.textAlignment = NSTextAlignmentCenter;
     tlabel.textColor = [BTUIKAppearance sharedInstance].navigationBarTitleTextColor;
-    tlabel.font = [UIFont fontWithName:[BTUIKAppearance sharedInstance].boldFontFamily size:[UIFont labelFontSize]];
+    tlabel.font = [[BTUIKAppearance sharedInstance].boldFont fontWithSize:UIFont.labelFontSize];
     tlabel.backgroundColor = UIColor.clearColor;
     tlabel.adjustsFontSizeToFitWidth = YES;
     tlabel.numberOfLines = 2;

--- a/BraintreeUIKit/Public/BTUIKAppearance.h
+++ b/BraintreeUIKit/Public/BTUIKAppearance.h
@@ -3,10 +3,10 @@
 @interface BTUIKAppearance : NSObject
 
 /// Shared instance used by Form elements
-+ (instancetype) sharedInstance;
++ (instancetype)sharedInstance;
 
-+ (void) darkTheme;
-+ (void) lightTheme;
++ (void)darkTheme;
++ (void)lightTheme;
 
 /// Fallback color for the overlay if blur is disabled
 @property (nonatomic, strong) UIColor *overlayColor;
@@ -14,10 +14,10 @@
 @property (nonatomic, strong) UIColor *tintColor;
 /// Bar color
 @property (nonatomic, strong) UIColor *barBackgroundColor;
-/// Font family
-@property (nonatomic, strong) NSString *fontFamily;
-/// Bold font family
-@property (nonatomic, strong) NSString *boldFontFamily;
+/// Font, size of font will be ignored
+@property (nonatomic, strong) UIFont *font;
+/// Bold font, size of font will be ignored
+@property (nonatomic, strong) UIFont *boldFont;
 /// Sheet background color
 @property (nonatomic, strong) UIColor *formBackgroundColor;
 /// Form field background color
@@ -52,26 +52,31 @@
 /// Tint color for UISwitch thumb
 @property (nonatomic, strong) UIColor *switchThumbTintColor;
 
+/// Font family
+@property (nonatomic, strong) NSString *fontFamily DEPRECATED_MSG_ATTRIBUTE("Use font instead.");
+/// Bold font family
+@property (nonatomic, strong) NSString *boldFontFamily DEPRECATED_MSG_ATTRIBUTE("Use boldFont instead.");
+
 /// Sets the color (primary or secondary) and font with family and size (large or small)
 /// These properties are on the [BTUIKAppearance sharedInstance]
-+ (void) styleLabelPrimary:(UILabel *) label;
-+ (void) styleLabelBoldPrimary:(UILabel *) label;
-+ (void) styleSmallLabelBoldPrimary:(UILabel *)label;
-+ (void) styleSmallLabelPrimary:(UILabel *)label;
-+ (void) styleLabelSecondary:(UILabel *)label;
-+ (void) styleLargeLabelSecondary:(UILabel *)label;
-+ (void) styleSystemLabelSecondary:(UILabel *)label;
-+ (UILabel *) styledNavigationTitleLabel;
++ (void)styleLabelPrimary:(UILabel *)label;
++ (void)styleLabelBoldPrimary:(UILabel *)label;
++ (void)styleSmallLabelBoldPrimary:(UILabel *)label;
++ (void)styleSmallLabelPrimary:(UILabel *)label;
++ (void)styleLabelSecondary:(UILabel *)label;
++ (void)styleLargeLabelSecondary:(UILabel *)label;
++ (void)styleSystemLabelSecondary:(UILabel *)label;
++ (UILabel *)styledNavigationTitleLabel;
 
-+ (float) horizontalFormContentPadding;
-+ (float) formCellHeight;
-+ (float) verticalFormSpace;
-+ (float) verticalFormSpaceTight;
-+ (float) verticalSectionSpace;
-+ (float) smallIconWidth;
-+ (float) smallIconHeight;
-+ (float) largeIconWidth;
-+ (float) largeIconHeight;
++ (float)horizontalFormContentPadding;
++ (float)formCellHeight;
++ (float)verticalFormSpace;
++ (float)verticalFormSpaceTight;
++ (float)verticalSectionSpace;
++ (float)smallIconWidth;
++ (float)smallIconHeight;
++ (float)largeIconWidth;
++ (float)largeIconHeight;
 + (NSDictionary*)metrics;
 
 @end

--- a/BraintreeUIKit/Public/BTUIKAppearance.h
+++ b/BraintreeUIKit/Public/BTUIKAppearance.h
@@ -10,7 +10,7 @@
 
 /// Fallback color for the overlay if blur is disabled
 @property (nonatomic, strong) UIColor *overlayColor;
-/// Tint color, defaults to 007aff
+/// Tint color
 @property (nonatomic, strong) UIColor *tintColor;
 /// Bar color
 @property (nonatomic, strong) UIColor *barBackgroundColor;
@@ -18,10 +18,10 @@
 @property (nonatomic, strong) NSString *fontFamily;
 /// Bold font family
 @property (nonatomic, strong) NSString *boldFontFamily;
-// Font
-@property (nonatomic, readonly, strong) UIFont *font;
-// Bold font
-@property (nonatomic, readonly, strong) UIFont *boldFont;
+// Font, defaults to system font
+@property (nonatomic, strong, readonly) UIFont *font;
+// Bold font, defaults to system bold font
+@property (nonatomic, strong, readonly) UIFont *boldFont;
 /// Sheet background color
 @property (nonatomic, strong) UIColor *formBackgroundColor;
 /// Form field background color

--- a/BraintreeUIKit/Public/BTUIKAppearance.h
+++ b/BraintreeUIKit/Public/BTUIKAppearance.h
@@ -14,10 +14,14 @@
 @property (nonatomic, strong) UIColor *tintColor;
 /// Bar color
 @property (nonatomic, strong) UIColor *barBackgroundColor;
-/// Font, size of font will be ignored
-@property (nonatomic, strong) UIFont *font;
-/// Bold font, size of font will be ignored
-@property (nonatomic, strong) UIFont *boldFont;
+/// Font family
+@property (nonatomic, strong) NSString *fontFamily;
+/// Bold font family
+@property (nonatomic, strong) NSString *boldFontFamily;
+// Font
+@property (nonatomic, readonly, strong) UIFont *font;
+// Bold font
+@property (nonatomic, readonly, strong) UIFont *boldFont;
 /// Sheet background color
 @property (nonatomic, strong) UIColor *formBackgroundColor;
 /// Form field background color
@@ -51,11 +55,6 @@
 @property (nonatomic, strong) UIColor *switchOnTintColor;
 /// Tint color for UISwitch thumb
 @property (nonatomic, strong) UIColor *switchThumbTintColor;
-
-/// Font family
-@property (nonatomic, strong) NSString *fontFamily DEPRECATED_MSG_ATTRIBUTE("Use font instead.");
-/// Bold font family
-@property (nonatomic, strong) NSString *boldFontFamily DEPRECATED_MSG_ATTRIBUTE("Use boldFont instead.");
 
 /// Sets the color (primary or secondary) and font with family and size (large or small)
 /// These properties are on the [BTUIKAppearance sharedInstance]

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -40,16 +40,16 @@ PODS:
   - Braintree/Venmo (4.23.1):
     - Braintree/Core
     - Braintree/PayPalDataCollector
-  - BraintreeDropIn (7.1.0):
-    - BraintreeDropIn/DropIn (= 7.1.0)
-  - BraintreeDropIn/DropIn (7.1.0):
+  - BraintreeDropIn (7.2.0):
+    - BraintreeDropIn/DropIn (= 7.2.0)
+  - BraintreeDropIn/DropIn (7.2.0):
     - Braintree/Card (~> 4.23)
     - Braintree/Core (~> 4.23)
     - Braintree/PaymentFlow (~> 4.23)
     - Braintree/PayPal (~> 4.23)
     - Braintree/UnionPay (~> 4.23)
     - BraintreeDropIn/UIKit
-  - BraintreeDropIn/UIKit (7.1.0)
+  - BraintreeDropIn/UIKit (7.2.0)
   - CardIO (5.4.1)
   - Expecta (1.0.6)
   - FLEX (2.4.0)
@@ -112,7 +112,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AFNetworking: b6f891fdfaed196b46c7a83cf209e09697b94057
   Braintree: 21588ab236be1d1c68591f6a241658456d23aad0
-  BraintreeDropIn: a019fcbf4edb87c55780ec01d5db3998b19164ce
+  BraintreeDropIn: b63750373474f7ec336118cee40cf767d198a977
   CardIO: 56983b39b62f495fc6dae9ad7cf875143df06443
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   FLEX: bd1a39e55b56bb413b6f1b34b3c10a0dc44ef079
@@ -126,4 +126,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 4e0aed3571b1a2048ce7f0851c337ee6acf49556
 
-COCOAPODS: 1.7.1
+COCOAPODS: 1.7.2

--- a/UnitTests/BTUIKAppearanceTests.m
+++ b/UnitTests/BTUIKAppearanceTests.m
@@ -26,4 +26,22 @@
     XCTAssertEqual([BTUIKAppearance styledNavigationTitleLabel].textColor, [UIColor greenColor]);
 }
 
+- (void)test_settingFontFamily_returnsCorrectFont {
+    [BTUIKAppearance sharedInstance].fontFamily = @"Verdana";
+    XCTAssert([[BTUIKAppearance sharedInstance].font.fontName isEqualToString:@"Verdana"]);
+}
+
+- (void)test_settingBoldFontFamily_returnsCorrectBoldFont {
+    [BTUIKAppearance sharedInstance].boldFontFamily = @"Courier-Bold";
+    XCTAssert([[BTUIKAppearance sharedInstance].boldFont.fontName isEqualToString:@"Courier-Bold"]);
+}
+
+- (void)test_defaultFontFamily_returnsSystemFont {
+    XCTAssertEqual([BTUIKAppearance sharedInstance].font, [UIFont systemFontOfSize:10.0]);
+}
+
+- (void)test_defaultBoldFontFamily_returnsBoldSystemFont {
+    XCTAssertEqual([BTUIKAppearance sharedInstance].boldFont, [UIFont boldSystemFontOfSize:10.0]);
+}
+
 @end


### PR DESCRIPTION
On iOS 13 fetching the system font by name no longer works. This PR adds read-only `font` and `boldFont` properties to BTUIKAppearance and defaults them to system font and system bold font if the font family and bold font family are not specified.

**iOS 13 - Before**
-------------------
![Simulator Screen Shot - iPhone Xʀ - 2019-06-27 at 09 04 02](https://user-images.githubusercontent.com/51723734/60273084-ee3fac00-98ba-11e9-829f-ce5fa9302a3e.png)


**iOS 13 - After**
-------------------
![Simulator Screen Shot - iPhone Xʀ - 2019-06-27 at 09 05 31](https://user-images.githubusercontent.com/51723734/60273094-f1d33300-98ba-11e9-90eb-350ee44006bc.png)

