### PR TITLE
Remove Target SDK Checks

### DIFF
--- a/BraintreeUIKit/Components/BTUIKExpiryInputView.m
+++ b/BraintreeUIKit/Components/BTUIKExpiryInputView.m
@@ -98,11 +98,11 @@
                                                                        views:viewBindings]];
         
         id bottomReferenceView = self;
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
+
         if (@available(iOS 11.0, *)) {
             bottomReferenceView = self.safeAreaLayoutGuide;
         }
-#endif
+
         [self addConstraint:[NSLayoutConstraint constraintWithItem:self.monthCollectionView
                                                          attribute:NSLayoutAttributeBottom
                                                          relatedBy:0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree iOS Drop-in SDK - Release Notes
 
+## unreleased
+* UI changes to support iOS 13
+* Demo app maintenance
+* Remove unneeded pre-processor directives
+
 ## 7.2.0 (2019-06-17)
 
 * Add ability for merchant and/or customer to opt in/out of client side vaulting (card).

--- a/DropInDemo/Demo Base/BraintreeDemoAppDelegate.m
+++ b/DropInDemo/Demo Base/BraintreeDemoAppDelegate.m
@@ -20,25 +20,12 @@ NSString *BraintreeDemoAppDelegatePaymentsURLScheme = @"com.braintreepayments.Dr
     return YES;
 }
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 90000
 - (BOOL)application:(__unused UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString *,id> *)options {
     if ([[url.scheme lowercaseString] isEqualToString:[BraintreeDemoAppDelegatePaymentsURLScheme lowercaseString]]) {
         return [BTAppSwitch handleOpenURL:url options:options];
     }
     return YES;
 }
-#endif
-
-// Deprecated in iOS 9, but necessary to support < versions
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-implementations"
-- (BOOL)application:(__unused UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(__unused id)annotation {
-    if ([[url.scheme lowercaseString] isEqualToString:[BraintreeDemoAppDelegatePaymentsURLScheme lowercaseString]]) {
-        return [BTAppSwitch handleOpenURL:url sourceApplication:sourceApplication];
-    }
-    return YES;
-}
-#pragma clang diagnostic pop
 
 - (void)setupAppearance {
     UIColor *pleasantGray = [UIColor colorWithWhite:42/255.0f alpha:1.0f];

--- a/DropInDemo/Features/Drop In/BraintreeDemoDropInViewController.m
+++ b/DropInDemo/Features/Drop In/BraintreeDemoDropInViewController.m
@@ -305,7 +305,6 @@
     }
 }
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
 - (void)paymentAuthorizationViewController:(__unused PKPaymentAuthorizationViewController *)controller didAuthorizePayment:(PKPayment *)payment handler:(void (^)(PKPaymentAuthorizationResult * _Nonnull))completion API_AVAILABLE(ios(11.0), watchos(4.0)) {
     self.progressBlock(@"Apple Pay Did Authorize Payment");
     BTAPIClient *client = [[BTAPIClient alloc] initWithAuthorization:self.authorizationString];
@@ -320,7 +319,6 @@
         }
     }];
 }
-#endif
 
 - (void)paymentAuthorizationViewController:(__unused PKPaymentAuthorizationViewController *)controller
                        didAuthorizePayment:(PKPayment *)payment


### PR DESCRIPTION
This removes pre-processor directives that check the target (base) SDK since we require users of this framework to use Xcode 10+, which has a target SDK of iOS 12+. We're also removing the deprecated `openURL` method since we require a deployment target of iOS 9+.