### PR TITLE
Close Drop-In on tap outside

### DIFF
--- a/BraintreeDropIn/BTDropInController.m
+++ b/BraintreeDropIn/BTDropInController.m
@@ -32,7 +32,7 @@
 @interface BTDropInControllerDismissTransition : NSObject <UIViewControllerAnimatedTransitioning>
 @end
 
-@interface BTDropInController () <BTAppSwitchDelegate, BTDropInControllerDelegate, BTViewControllerPresentingDelegate, BTPaymentSelectionViewControllerDelegate, BTCardFormViewControllerDelegate, UIViewControllerTransitioningDelegate, BTThreeDSecureRequestDelegate>
+@interface BTDropInController () <BTAppSwitchDelegate, BTDropInControllerDelegate, BTViewControllerPresentingDelegate, BTPaymentSelectionViewControllerDelegate, BTCardFormViewControllerDelegate, UIViewControllerTransitioningDelegate, BTThreeDSecureRequestDelegate, UIGestureRecognizerDelegate>
 
 @property (nonatomic, strong) BTConfiguration *configuration;
 @property (nonatomic, strong, readwrite) BTAPIClient *apiClient;
@@ -147,6 +147,9 @@
     self.view.backgroundColor = [BTUIKAppearance sharedInstance].overlayColor;
     self.view.userInteractionEnabled = YES;
     
+    UITapGestureRecognizer *tapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(closeDropIn)];
+    tapRecognizer.delegate = self;
+    [self.view addGestureRecognizer:tapRecognizer];
     
     self.contentView = [[UIView alloc] init];
     self.contentView.translatesAutoresizingMaskIntoConstraints = NO;
@@ -438,6 +441,12 @@
 
 - (BOOL)isFormSheet {
     return self.modalPresentationStyle == UIModalPresentationFormSheet;
+}
+
+- (void)closeDropIn {
+    if (self.paymentSelectionViewController != NULL) {
+        [self dismissViewControllerAnimated:true completion:nil];
+    }
 }
 
 #pragma mark - UI Preferences

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * UI changes to support iOS 13
 * Demo app maintenance
 * Remove unneeded pre-processor directives
+* Close Drop-In on tap outside (NEXT_MAJOR_VERSION)
 
 ## 7.2.0 (2019-06-17)
 

--- a/UITests/BraintreeDropIn_UITests.swift
+++ b/UITests/BraintreeDropIn_UITests.swift
@@ -1176,3 +1176,31 @@ class BraintreeDropIn_SaveCardToggleHiddenForTokenizationKey_UITests: XCTestCase
         XCTAssertFalse(saveCardSwitch.exists)
     }
 }
+
+class BraintreeDropIn_DropInClosesOnTouchOutside_UITests: XCTestCase {
+
+    var app: XCUIApplication!
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchArguments.append("-EnvironmentSandbox")
+        app.launchArguments.append("-TokenizationKey")
+        app.launch()
+        sleep(1)
+    }
+
+    func testDropIn_dropInCloses_onTouchOutside() {
+        self.waitForElementToBeHittable(app.buttons["Add Payment Method"])
+        app.buttons["Add Payment Method"].tap()
+
+        let paymentMethodLabel = app.staticTexts["Select Payment Method"]
+        let tapCoordinate = paymentMethodLabel.coordinate(withNormalizedOffset: CGVector(dx: 0.0, dy: 50.0))
+        tapCoordinate.tap()
+
+        let closedLabel = app.staticTexts["Select Payment Method"]
+        XCTAssertFalse(closedLabel.exists)
+    }
+
+}


### PR DESCRIPTION
Adds the ability for a user to close the Drop-In on a touch outside the view. In many iOS subviews, the standard is to give the user the ability to close the view by touching outside of it, instead of only being able to perform this action through touching the "cancel" button. This also mirrors the behavior of the Android Drop-In.

This PR references [this issue](https://github.com/braintree/braintree-ios-drop-in/issues/152), in which I provided a workaround for this situation.