### PR TITLE
Deprecate BTDropInRequest `amount` property

### DIFF
--- a/BraintreeDropIn.xcodeproj/project.pbxproj
+++ b/BraintreeDropIn.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		03AE59581DDE7E8C000B594C /* BTUIKVisualAssetType.h in Headers */ = {isa = PBXBuildFile; fileRef = 03AE59571DDE7E8C000B594C /* BTUIKVisualAssetType.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		03B793AD1DAD61B500F54B1B /* BTDropInResultTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 03B793AC1DAD61B500F54B1B /* BTDropInResultTests.m */; };
 		03FFF6B01DB82E9D004A1F9B /* BTUI.strings in Resources */ = {isa = PBXBuildFile; fileRef = A52900E81D8903A600032220 /* BTUI.strings */; };
+		42A10ADA230EE4D700892302 /* BTDropInControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A10AD9230EE4D700892302 /* BTDropInControllerTests.swift */; };
 		53E78BE022248A29000388D3 /* BTUIKHipercardVectorArtView.h in Headers */ = {isa = PBXBuildFile; fileRef = 53E78BDC22248A29000388D3 /* BTUIKHipercardVectorArtView.h */; };
 		53E78BE322248A29000388D3 /* BTUIKHipercardVectorArtView.m in Sources */ = {isa = PBXBuildFile; fileRef = 53E78BDF22248A29000388D3 /* BTUIKHipercardVectorArtView.m */; };
 		53E78BE622248BC3000388D3 /* BTUIKLargeHiperVectorArtView.h in Headers */ = {isa = PBXBuildFile; fileRef = 53E78BE422248BC3000388D3 /* BTUIKLargeHiperVectorArtView.h */; };
@@ -269,6 +270,8 @@
 		03B793AC1DAD61B500F54B1B /* BTDropInResultTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BTDropInResultTests.m; sourceTree = "<group>"; };
 		1741E0093A0037D2EBE80FE4 /* Pods-Tests-UnitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-UnitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests.release.xcconfig"; sourceTree = "<group>"; };
 		273802B93A7925EB38CBFA75 /* Pods-DropInDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DropInDemo.debug.xcconfig"; path = "Pods/Target Support Files/Pods-DropInDemo/Pods-DropInDemo.debug.xcconfig"; sourceTree = "<group>"; };
+		42A10AD8230EE4D600892302 /* UnitTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UnitTests-Bridging-Header.h"; sourceTree = "<group>"; };
+		42A10AD9230EE4D700892302 /* BTDropInControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTDropInControllerTests.swift; sourceTree = "<group>"; };
 		4E893F56079C5D0E5FB1FF07 /* Pods-Tests-UnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests-UnitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Tests-UnitTests/Pods-Tests-UnitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		53E78BDC22248A29000388D3 /* BTUIKHipercardVectorArtView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BTUIKHipercardVectorArtView.h; sourceTree = "<group>"; };
 		53E78BDF22248A29000388D3 /* BTUIKHipercardVectorArtView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BTUIKHipercardVectorArtView.m; sourceTree = "<group>"; };
@@ -765,6 +768,8 @@
 				031F576E1E8EE0FB0013B5ED /* BTUIKAppearanceTests.m */,
 				034D31991E8EEC4B0056F5AA /* BTDropInBaseViewControllerTests.m */,
 				034B5C12203CDFD0001A01DE /* BTUIKCardListLabelTests.m */,
+				42A10AD9230EE4D700892302 /* BTDropInControllerTests.swift */,
+				42A10AD8230EE4D600892302 /* UnitTests-Bridging-Header.h */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
@@ -1184,6 +1189,7 @@
 					};
 					A5411A1B1D8A1F090041BE92 = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 1030;
 						TestTargetID = A5CE1D131D835832009BE61A;
 					};
 					A5411A291D8A20D00041BE92 = {
@@ -1458,6 +1464,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				034D319A1E8EEC4B0056F5AA /* BTDropInBaseViewControllerTests.m in Sources */,
+				42A10ADA230EE4D700892302 /* BTDropInControllerTests.swift in Sources */,
 				034B5C13203CDFD0001A01DE /* BTUIKCardListLabelTests.m in Sources */,
 				A50ED7A81D8B02AF00A78EF0 /* BTUIKViewUtilTests.m in Sources */,
 				A5672DAC1DC9369D0058485E /* BTUIKCardTypeTests.m in Sources */,
@@ -1707,6 +1714,7 @@
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
@@ -1740,6 +1748,9 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.braintreepayments.UnitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "UnitTests/UnitTests-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/DropInDemo.app/DropInDemo";
 			};
 			name = Debug;
@@ -1753,6 +1764,7 @@
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
@@ -1781,6 +1793,8 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.braintreepayments.UnitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "UnitTests/UnitTests-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/DropInDemo.app/DropInDemo";
 				VALIDATE_PRODUCT = YES;
 			};

--- a/BraintreeDropIn/Public/BTDropInRequest.h
+++ b/BraintreeDropIn/Public/BTDropInRequest.h
@@ -12,13 +12,13 @@ typedef NS_ENUM(NSInteger, BTFormFieldSetting) {
 
 @interface BTDropInRequest : NSObject <NSCopying>
 
-/// Optional: Amount of the transaction for ThreeDSecure flows.
+/// Optional: Amount of the transaction for ThreeDSecure flows. If `threeDSecureRequest.amount` is set, this value will be ignored.
 ///
 /// Amount must be a non-negative number, may optionally contain exactly 2 decimal places
 /// separated by '.', optional thousands separator ',', limited to 7 digits before the decimal point.
 ///
 /// Note: You must still set the amount on the `payPalRequest` for PayPal checkout flows.
-@property (nonatomic, copy, nullable) NSString *amount;
+@property (nonatomic, copy, nullable) NSString *amount DEPRECATED_MSG_ATTRIBUTE("Use `threeDSecureRequest.amount` instead.");
 
 /// Optional: Specify the options for the PayPal flow. If not present, a default vault flow will be used.
 ///

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Braintree iOS Drop-in SDK - Release Notes
 
+## unreleased
+
+* Deprecate `amount` property on `BTDropInRequest`
+
 ## 7.3.0 (2019-08-09)
+
 * UI changes to support iOS 13
 * Demo app maintenance
 * Remove unneeded pre-processor directives

--- a/DropInDemo/Demo Base/BraintreeDemoAppDelegate.m
+++ b/DropInDemo/Demo Base/BraintreeDemoAppDelegate.m
@@ -3,6 +3,7 @@
 #import "BraintreeDemoDemoContainmentViewController.h"
 #import "BraintreeCore.h"
 #import "BTDropInOverrides.h"
+#import "BraintreePaymentFlow.h"
 
 NSString *BraintreeDemoAppDelegatePaymentsURLScheme = @"com.braintreepayments.DropInDemo.payments";
 
@@ -49,9 +50,9 @@ NSString *BraintreeDemoAppDelegatePaymentsURLScheme = @"com.braintreepayments.Dr
     }
 
     if ([[[NSProcessInfo processInfo] arguments] containsObject:@"-ThreeDSecureVersion2"]) {
-        [[NSUserDefaults standardUserDefaults] setInteger:BraintreeDemoTransactionServiceThreeDSecureRequestedVersion2 forKey:BraintreeDemoSettingsThreeDSecureVersionDefaultsKey];
+        [[NSUserDefaults standardUserDefaults] setInteger:BTThreeDSecureVersion2 forKey:BraintreeDemoSettingsThreeDSecureVersionDefaultsKey];
     } else if ([[[NSProcessInfo processInfo] arguments] containsObject:@"-ThreeDSecureVersionLegacy"]) {
-        [[NSUserDefaults standardUserDefaults] setInteger:BraintreeDemoTransactionServiceThreeDSecureRequestedVersionLegacy forKey:BraintreeDemoSettingsThreeDSecureVersionDefaultsKey];
+        [[NSUserDefaults standardUserDefaults] setInteger:BTThreeDSecureVersion1 forKey:BraintreeDemoSettingsThreeDSecureVersionDefaultsKey];
     }
 
     if ([[[NSProcessInfo processInfo] arguments] containsObject:@"-TokenizationKey"]) {

--- a/DropInDemo/Demo Base/Settings/BraintreeDemoSettings.h
+++ b/DropInDemo/Demo Base/Settings/BraintreeDemoSettings.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 #import <BraintreeDropIn/BTDropInRequest.h>
-#import <BraintreePaymentFlow.h>
+#import <Braintree/BraintreePaymentFlow.h>
 
 extern NSString *BraintreeDemoSettingsEnvironmentDefaultsKey;
 extern NSString *BraintreeDemoSettingsCustomEnvironmentURLDefaultsKey;

--- a/DropInDemo/Demo Base/Settings/BraintreeDemoSettings.h
+++ b/DropInDemo/Demo Base/Settings/BraintreeDemoSettings.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 #import <BraintreeDropIn/BTDropInRequest.h>
+#import <BraintreePaymentFlow.h>
 
 extern NSString *BraintreeDemoSettingsEnvironmentDefaultsKey;
 extern NSString *BraintreeDemoSettingsCustomEnvironmentURLDefaultsKey;
@@ -18,11 +19,6 @@ typedef NS_ENUM(NSInteger, BraintreeDemoTransactionServiceThreeDSecureRequiredSt
     BraintreeDemoTransactionServiceThreeDSecureRequiredStatusNotRequired = 2,
 };
 
-typedef NS_ENUM(NSInteger, BraintreeDemoTransactionServiceThreeDSecureRequestedVersion) {
-    BraintreeDemoTransactionServiceThreeDSecureRequestedVersionLegacy = 0,
-    BraintreeDemoTransactionServiceThreeDSecureRequestedVersion2 = 1,
-};
-
 @interface BraintreeDemoSettings : NSObject
 
 + (BraintreeDemoTransactionServiceEnvironment)currentEnvironment;
@@ -31,7 +27,7 @@ typedef NS_ENUM(NSInteger, BraintreeDemoTransactionServiceThreeDSecureRequestedV
 + (NSString *)authorizationOverride;
 + (BOOL)useTokenizationKey;
 + (BraintreeDemoTransactionServiceThreeDSecureRequiredStatus)threeDSecureRequiredStatus;
-+ (BraintreeDemoTransactionServiceThreeDSecureRequestedVersion)threeDSecureRequestedVersion;
++ (BTThreeDSecureVersion)threeDSecureRequestedVersion;
 + (BOOL)useModalPresentation;
 + (BOOL)customerPresent;
 + (NSString *)customerIdentifier;

--- a/DropInDemo/Demo Base/Settings/BraintreeDemoSettings.m
+++ b/DropInDemo/Demo Base/Settings/BraintreeDemoSettings.m
@@ -50,7 +50,7 @@ NSString *BraintreeDemoSettingsThreeDSecureVersionDefaultsKey = @"BraintreeDemoS
     return [[NSUserDefaults standardUserDefaults] integerForKey:BraintreeDemoSettingsThreeDSecureRequiredDefaultsKey];
 }
 
-+ (BraintreeDemoTransactionServiceThreeDSecureRequestedVersion)threeDSecureRequestedVersion {
++ (BTThreeDSecureVersion)threeDSecureRequestedVersion {
     return [[NSUserDefaults standardUserDefaults]
         integerForKey:BraintreeDemoSettingsThreeDSecureVersionDefaultsKey];
 }

--- a/DropInDemo/Features/Drop In/BraintreeDemoDropInViewController.m
+++ b/DropInDemo/Features/Drop In/BraintreeDemoDropInViewController.m
@@ -257,33 +257,26 @@
         dropInRequest.payPalRequest = [[BTPayPalRequest alloc] initWithAmount:@"4.77"];
     }
 
-    if ([BraintreeDemoSettings threeDSecureRequiredStatus] == BraintreeDemoTransactionServiceThreeDSecureRequiredStatusRequired) {
+    if (BraintreeDemoSettings.threeDSecureRequiredStatus == BraintreeDemoTransactionServiceThreeDSecureRequiredStatusRequired) {
         dropInRequest.threeDSecureVerification = YES;
-        if ([BraintreeDemoSettings threeDSecureRequestedVersion] == BraintreeDemoTransactionServiceThreeDSecureRequestedVersion2) {
-            BTThreeDSecureRequest *threeDSecureRequest = [BTThreeDSecureRequest new];
-            threeDSecureRequest.amount = [NSDecimalNumber decimalNumberWithString:@"10.32"];
-            threeDSecureRequest.versionRequested = BTThreeDSecureVersion2;
-
-            BTThreeDSecurePostalAddress *billingAddress = [BTThreeDSecurePostalAddress new];
-            billingAddress.givenName = @"Jill";
-            billingAddress.surname = @"Doe";
-            billingAddress.streetAddress = @"555 Smith St.";
-            billingAddress.extendedAddress = @"#5";
-            billingAddress.locality = @"Oakland";
-            billingAddress.region = @"CA";
-            billingAddress.countryCodeAlpha2 = @"US";
-            billingAddress.postalCode = @"12345";
-            billingAddress.phoneNumber = @"8101234567";
-            threeDSecureRequest.billingAddress = billingAddress;
-            threeDSecureRequest.email = @"test@example.com";
-            threeDSecureRequest.shippingMethod = @"01";
-            dropInRequest.threeDSecureRequest = threeDSecureRequest;
-        } else {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-            dropInRequest.amount = @"10.00";
-#pragma clang diagnostic pop
-        }
+        BTThreeDSecureRequest *threeDSecureRequest = [BTThreeDSecureRequest new];
+        threeDSecureRequest.amount = [NSDecimalNumber decimalNumberWithString:@"10.32"];
+        threeDSecureRequest.versionRequested = BraintreeDemoSettings.threeDSecureRequestedVersion;
+        
+        BTThreeDSecurePostalAddress *billingAddress = [BTThreeDSecurePostalAddress new];
+        billingAddress.givenName = @"Jill";
+        billingAddress.surname = @"Doe";
+        billingAddress.streetAddress = @"555 Smith St.";
+        billingAddress.extendedAddress = @"#5";
+        billingAddress.locality = @"Oakland";
+        billingAddress.region = @"CA";
+        billingAddress.countryCodeAlpha2 = @"US";
+        billingAddress.postalCode = @"12345";
+        billingAddress.phoneNumber = @"8101234567";
+        threeDSecureRequest.billingAddress = billingAddress;
+        threeDSecureRequest.email = @"test@example.com";
+        threeDSecureRequest.shippingMethod = @"01";
+        dropInRequest.threeDSecureRequest = threeDSecureRequest;
     }
 
     BTDropInController *dropIn = [[BTDropInController alloc] initWithAuthorization:self.authorizationString request:dropInRequest handler:^(BTDropInController * _Nonnull dropInController, BTDropInResult * _Nullable result, NSError * _Nullable error) {

--- a/DropInDemo/Features/Drop In/BraintreeDemoDropInViewController.m
+++ b/DropInDemo/Features/Drop In/BraintreeDemoDropInViewController.m
@@ -258,7 +258,6 @@
     }
 
     if ([BraintreeDemoSettings threeDSecureRequiredStatus] == BraintreeDemoTransactionServiceThreeDSecureRequiredStatusRequired) {
-        dropInRequest.amount = @"10.00";
         dropInRequest.threeDSecureVerification = YES;
         if ([BraintreeDemoSettings threeDSecureRequestedVersion] == BraintreeDemoTransactionServiceThreeDSecureRequestedVersion2) {
             BTThreeDSecureRequest *threeDSecureRequest = [BTThreeDSecureRequest new];
@@ -279,6 +278,11 @@
             threeDSecureRequest.email = @"test@example.com";
             threeDSecureRequest.shippingMethod = @"01";
             dropInRequest.threeDSecureRequest = threeDSecureRequest;
+        } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+            dropInRequest.amount = @"10.00";
+#pragma clang diagnostic pop
         }
     }
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -40,16 +40,16 @@ PODS:
   - Braintree/Venmo (4.26.3):
     - Braintree/Core
     - Braintree/PayPalDataCollector
-  - BraintreeDropIn (7.2.0):
-    - BraintreeDropIn/DropIn (= 7.2.0)
-  - BraintreeDropIn/DropIn (7.2.0):
+  - BraintreeDropIn (7.3.0):
+    - BraintreeDropIn/DropIn (= 7.3.0)
+  - BraintreeDropIn/DropIn (7.3.0):
     - Braintree/Card (~> 4.26.1)
     - Braintree/Core (~> 4.26.1)
     - Braintree/PaymentFlow (~> 4.26.1)
     - Braintree/PayPal (~> 4.26.1)
     - Braintree/UnionPay (~> 4.26.1)
     - BraintreeDropIn/UIKit
-  - BraintreeDropIn/UIKit (7.2.0)
+  - BraintreeDropIn/UIKit (7.3.0)
   - CardIO (5.4.1)
   - Expecta (1.0.6)
   - InAppSettingsKit (2.12)
@@ -104,7 +104,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AFNetworking: b6f891fdfaed196b46c7a83cf209e09697b94057
   Braintree: b90c685c851aea899eeae22f8cf708e906c384ff
-  BraintreeDropIn: 6e192775856433c0acaeba84e3bf19c6924f2e15
+  BraintreeDropIn: 1cfb2ea86b9b5c7685406f9ff579f5dc74853db1
   CardIO: 56983b39b62f495fc6dae9ad7cf875143df06443
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   InAppSettingsKit: 363ed5ea061ebcb76d69ca1eed08c8a4fe48baf2

--- a/UnitTests/BTDropInControllerTests.swift
+++ b/UnitTests/BTDropInControllerTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+
+class BTDropInControllerTests: XCTestCase {
+    
+    func testInitWithAuthorization_createsThreeDSecureRequest_whenAmountIsSet_andThreeDSecureIsRequested() {
+        let dropInRequest = BTDropInRequest()
+        dropInRequest.amount = "12.54"
+        dropInRequest.threeDSecureVerification = true
+        
+        let dropInController = BTDropInController(authorization: "development_tokenization_key",
+                                                  request: dropInRequest,
+                                                  handler: nil)
+        
+        XCTAssertEqual(dropInController?.dropInRequest.threeDSecureRequest?.amount, NSDecimalNumber(string: "12.54"))
+    }
+    
+    func testInitWithAuthorization_doesNotCreateThreeDSecureRequest_whenThreeDSecureIsNotRequested() {
+        let dropInRequest = BTDropInRequest()
+        dropInRequest.amount = "12.54"
+        dropInRequest.threeDSecureVerification = false
+        
+        let dropInController = BTDropInController(authorization: "development_tokenization_key",
+                                                  request: dropInRequest,
+                                                  handler: nil)
+        
+        XCTAssertNil(dropInController?.dropInRequest.threeDSecureRequest)
+    }
+    
+    func testInitWithAuthorization_doesNotCreateThreeDSecureRequest_whenAmountIsNotSet() {
+        let dropInRequest = BTDropInRequest()
+        dropInRequest.threeDSecureVerification = true
+        
+        let dropInController = BTDropInController(authorization: "development_tokenization_key",
+                                                  request: dropInRequest,
+                                                  handler: nil)
+        
+        XCTAssertNil(dropInController?.dropInRequest.threeDSecureRequest)
+    }
+    
+    func testInitWithAuthorization_doesNotOverrideThreeDSecureRequest_whenThreeDSecureRequestAlreadyExists() {
+        let dropInRequest = BTDropInRequest()
+        dropInRequest.amount = "12.54"
+        dropInRequest.threeDSecureVerification = true
+        
+        let threeDSecureRequest = BTThreeDSecureRequest()
+        threeDSecureRequest.amount = NSDecimalNumber(string: "100.34")
+        dropInRequest.threeDSecureRequest = threeDSecureRequest
+        
+        let dropInController = BTDropInController(authorization: "development_tokenization_key",
+                                                  request: dropInRequest,
+                                                  handler: nil)
+        
+        XCTAssertEqual(dropInController?.dropInRequest.threeDSecureRequest?.amount, NSDecimalNumber(string: "100.34"))
+    }
+}

--- a/UnitTests/BTDropInRequestTests.m
+++ b/UnitTests/BTDropInRequestTests.m
@@ -37,7 +37,12 @@
     threeDSecureRequest.additionalInformation = info;
 
     BTDropInRequest *originalRequest = [BTDropInRequest new];
+    
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     originalRequest.amount = @"10.02";
+#pragma clang diagnostic pop
+    
     originalRequest.payPalRequest = [[BTPayPalRequest alloc] initWithAmount:@"10.01"];
     originalRequest.applePayDisabled = YES;
     originalRequest.paypalDisabled = YES;
@@ -53,7 +58,11 @@
 
     BTDropInRequest *copiedRequest = [originalRequest copy];
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     XCTAssertEqual(originalRequest.amount, copiedRequest.amount);
+#pragma clang diagnostic pop
+    
     XCTAssertEqual(originalRequest.payPalRequest, copiedRequest.payPalRequest);
     XCTAssertEqual(originalRequest.applePayDisabled, copiedRequest.applePayDisabled);
     XCTAssertEqual(originalRequest.paypalDisabled, copiedRequest.paypalDisabled);

--- a/UnitTests/BTDropInResultTests.m
+++ b/UnitTests/BTDropInResultTests.m
@@ -7,16 +7,6 @@
 
 @implementation BTDropInResultTests
 
-- (void)setUp {
-    [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-}
-
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-    [super tearDown];
-}
-
 - (void)testFetchDropInResultForAuthorization {
     XCTestExpectation *expectation = [self expectationWithDescription:@"High Expectations"];
     NSURL *clientTokenURL = [NSURL URLWithString:@"https://braintree-sample-merchant.herokuapp.com/client_token"];

--- a/UnitTests/BTPaymentSelectionViewControllerTests.m
+++ b/UnitTests/BTPaymentSelectionViewControllerTests.m
@@ -13,16 +13,6 @@
 
 @implementation BTPaymentSelectionViewControllerTests
 
-- (void)setUp {
-    [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-}
-
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-    [super tearDown];
-}
-
 - (void)test_configurationLoaded_hasCreditCardsInSupportedCardTypes {
     NSError *error = nil;
     NSDictionary *configurationJSON = @{

--- a/UnitTests/UnitTests-Bridging-Header.h
+++ b/UnitTests/UnitTests-Bridging-Header.h
@@ -1,0 +1,6 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import "BraintreeDropIn.h"
+#import "BraintreePaymentFlow.h"


### PR DESCRIPTION
## Summary
Deprecating the `amount` property on `BTDropInRequest`. Instead, the amount for 3DS flows should be set on `BTThreeDSecureRequest`.