### PR TITLE
Show activity indicator on 3DS flow with vaulted payment method

### DIFF
--- a/BraintreeDropIn/BTDropInController.m
+++ b/BraintreeDropIn/BTDropInController.m
@@ -323,7 +323,6 @@
 }
 
 - (void)onLookupComplete:(__unused BTThreeDSecureRequest *)request result:(__unused BTThreeDSecureLookup *)result next:(void (^)(void))next {
-    [self.paymentSelectionViewController showLoadingScreen:NO];
     next();
 }
 

--- a/BraintreeDropIn/BTDropInController.m
+++ b/BraintreeDropIn/BTDropInController.m
@@ -108,17 +108,12 @@
     [self.apiClient sendAnalyticsEvent:@"ios.dropin2.appear"];
 }
 
-- (void)viewDidAppear:(BOOL)animated {
-    [super viewDidAppear:animated];
-}
-
 - (void)viewWillDisappear:(BOOL)animated {
     [super viewWillDisappear:animated];
     [self.apiClient sendAnalyticsEvent:@"ios.dropin2.disappear"];
 }
 
-- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
-{
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
     // before rotating
     [coordinator animateAlongsideTransition:^(__unused id<UIViewControllerTransitionCoordinatorContext> context) {
@@ -311,7 +306,7 @@
 
     [paymentFlowDriver startPaymentFlow:request completion:^(BTPaymentFlowResult * _Nonnull result, NSError * _Nonnull error) {
         BTThreeDSecureResult *threeDSecureResult = (BTThreeDSecureResult *)result;
-
+        [self.paymentSelectionViewController showLoadingScreen:NO];
         if (self.handler) {
             BTDropInResult *dropInResult = [[BTDropInResult alloc] init];
             if (threeDSecureResult.tokenizedCard != nil) {
@@ -328,6 +323,7 @@
 }
 
 - (void)onLookupComplete:(__unused BTThreeDSecureRequest *)request result:(__unused BTThreeDSecureLookup *)result next:(void (^)(void))next {
+    [self.paymentSelectionViewController showLoadingScreen:NO];
     next();
 }
 
@@ -499,6 +495,7 @@
             result.paymentOptionType = type;
             result.paymentMethod = nonce;
             if ([BTUIKViewUtil isPaymentOptionTypeACreditCard:result.paymentOptionType] && [self.configuration.json[@"threeDSecureEnabled"] isTrue] && self.dropInRequest.threeDSecureRequest) {
+                [self.paymentSelectionViewController showLoadingScreen:YES];
                 [self threeDSecureVerification:nonce];
             } else {
                 self.handler(self, result, error);

--- a/BraintreeDropIn/BTPaymentSelectionViewController.m
+++ b/BraintreeDropIn/BTPaymentSelectionViewController.m
@@ -424,7 +424,8 @@ static BOOL _vaultedCardAppearAnalyticSent = NO;
     BTUIPaymentMethodCollectionViewCell *cell = (BTUIPaymentMethodCollectionViewCell*)[savedPaymentMethodsCollectionView cellForItemAtIndexPath:indexPath];
     if (self.delegate) {
         [self.delegate selectionCompletedWithPaymentMethodType:[BTUIKViewUtil paymentOptionTypeForPaymentInfoType:cell.paymentMethodNonce.type]
-                                                         nonce:cell.paymentMethodNonce error:nil];
+                                                         nonce:cell.paymentMethodNonce
+                                                         error:nil];
 
         if ([cell.paymentMethodNonce isKindOfClass:[BTCardNonce class]]) {
             [self.apiClient sendAnalyticsEvent:@"ios.dropin2.vaulted-card.select"];

--- a/BraintreeDropIn/BTPaymentSelectionViewController.m
+++ b/BraintreeDropIn/BTPaymentSelectionViewController.m
@@ -198,8 +198,12 @@ static BOOL _vaultedCardAppearAnalyticSent = NO;
 
 - (void)loadConfiguration {
     [self showLoadingScreen:YES];
-    self.stackView.hidden = YES;
     [super loadConfiguration];
+}
+
+- (void)showLoadingScreen:(BOOL)show {
+    [super showLoadingScreen:show];
+    self.stackView.hidden = show;
 }
 
 - (void)dealloc {
@@ -271,7 +275,6 @@ static BOOL _vaultedCardAppearAnalyticSent = NO;
                 [self sendVaultedCardAppearAnalytic];
             }
             [self showLoadingScreen:NO];
-            self.stackView.hidden = NO;
             [self.view layoutIfNeeded];
             if (self.delegate) {
                 [self.delegate sheetHeightDidChange:self];
@@ -420,9 +423,10 @@ static BOOL _vaultedCardAppearAnalyticSent = NO;
 - (void)collectionView:(__unused UICollectionView *)savedPaymentMethodsCollectionView didSelectItemAtIndexPath:(__unused NSIndexPath *)indexPath {
     BTUIPaymentMethodCollectionViewCell *cell = (BTUIPaymentMethodCollectionViewCell*)[savedPaymentMethodsCollectionView cellForItemAtIndexPath:indexPath];
     if (self.delegate) {
-        [self.delegate selectionCompletedWithPaymentMethodType:[BTUIKViewUtil paymentOptionTypeForPaymentInfoType:cell.paymentMethodNonce.type] nonce:cell.paymentMethodNonce error:nil];
+        [self.delegate selectionCompletedWithPaymentMethodType:[BTUIKViewUtil paymentOptionTypeForPaymentInfoType:cell.paymentMethodNonce.type]
+                                                         nonce:cell.paymentMethodNonce error:nil];
 
-        if ([cell.paymentMethodNonce isKindOfClass: [BTCardNonce class]]){
+        if ([cell.paymentMethodNonce isKindOfClass:[BTCardNonce class]]) {
             [self.apiClient sendAnalyticsEvent:@"ios.dropin2.vaulted-card.select"];
         }
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Braintree iOS Drop-in SDK - Release Notes
 
+## unreleased
+
+* Show activity indicator when 3D Secure flow is triggered for a vaulted payment method
+
 ## 7.3.0 (2019-08-09)
+
 * UI changes to support iOS 13
 * Demo app maintenance
 * Remove unneeded pre-processor directives

--- a/DropInDemo/Demo Base/BraintreeDemoAppDelegate.m
+++ b/DropInDemo/Demo Base/BraintreeDemoAppDelegate.m
@@ -65,7 +65,6 @@ NSString *BraintreeDemoAppDelegatePaymentsURLScheme = @"com.braintreepayments.Dr
 
     if ([[[NSProcessInfo processInfo] arguments] containsObject:@"-EditModeCustomer"]) {
         // Customer "123-edit-test" has vaulted payment methods
-        // If customer "123-edit-test" doesn't
         [[NSUserDefaults standardUserDefaults] setObject:@"123-edit-test" forKey:@"BraintreeDemoCustomerIdentifier"];
     }
 

--- a/DropInDemo/Demo Base/BraintreeDemoAppDelegate.m
+++ b/DropInDemo/Demo Base/BraintreeDemoAppDelegate.m
@@ -63,8 +63,8 @@ NSString *BraintreeDemoAppDelegatePaymentsURLScheme = @"com.braintreepayments.Dr
         [[NSUserDefaults standardUserDefaults] setObject:@"" forKey:@"BraintreeDemoCustomerIdentifier"];
     }
 
-    if ([[[NSProcessInfo processInfo] arguments] containsObject:@"-EditModeCustomer"]) {
-        // Customer "123-edit-test" has vaulted payment methods
+    if ([[[NSProcessInfo processInfo] arguments] containsObject:@"-CustomerIDWithVaultedPaymentMethods"]) {
+        // Customer ID "123-edit-test" has vaulted payment methods
         [[NSUserDefaults standardUserDefaults] setObject:@"123-edit-test" forKey:@"BraintreeDemoCustomerIdentifier"];
     }
 

--- a/DropInDemo/Features/Drop In/BraintreeDemoDropInViewController.m
+++ b/DropInDemo/Features/Drop In/BraintreeDemoDropInViewController.m
@@ -226,8 +226,7 @@
     } else if ([BraintreeDemoSettings threeDSecureRequiredStatus] == BraintreeDemoTransactionServiceThreeDSecureRequiredStatusRequired
                && [self nonceRequiresThreeDSecureVerification:self.selectedNonce]) {
         [self performThreeDSecureVerification];
-    }
-    else {
+    } else {
         self.completionBlock(self.selectedNonce);
         self.transactionBlock();
     }
@@ -282,25 +281,29 @@
         }
     }
 
-    BTDropInController *dropIn = [[BTDropInController alloc] initWithAuthorization:self.authorizationString request:dropInRequest handler:^(BTDropInController * _Nonnull dropInController, BTDropInResult * _Nullable result, NSError * _Nullable error) {
-        if (error) {
-            self.progressBlock([NSString stringWithFormat:@"Error: %@", error.localizedDescription]);
-            NSLog(@"Error: %@", error);
-        } else if (result.isCancelled) {
-            self.progressBlock(@"Cancelled🎲");
-        } else {
-            if (result.paymentOptionType == BTUIKPaymentOptionTypeApplePay) {
-                self.progressBlock(@"Ready for checkout...");
-                [self setupApplePay];
-            } else {
-                self.useApplePay = NO;
-                self.selectedNonce = result.paymentMethod;
-                self.progressBlock(@"Ready for checkout...");
-                [self updatePaymentMethod:self.selectedNonce];
-            }
-        }
-        [dropInController dismissViewControllerAnimated:YES completion:nil];
-    }];
+    BTDropInController *dropIn = [[BTDropInController alloc] initWithAuthorization:self.authorizationString
+                                                                           request:dropInRequest
+                                                                           handler:^(BTDropInController * _Nonnull dropInController,
+                                                                                     BTDropInResult * _Nullable result,
+                                                                                     NSError * _Nullable error) {
+                                                                               
+                                                                               if (error) {
+                                                                                   self.progressBlock([NSString stringWithFormat:@"Error: %@", error.localizedDescription]);
+                                                                                   NSLog(@"Error: %@", error);
+                                                                               } else if (result.isCancelled) {
+                                                                                   self.progressBlock(@"Cancelled🎲");
+                                                                               } else if (result.paymentOptionType == BTUIKPaymentOptionTypeApplePay) {
+                                                                                   self.progressBlock(@"Ready for checkout...");
+                                                                                   [self setupApplePay];
+                                                                               } else {
+                                                                                   self.useApplePay = NO;
+                                                                                   self.selectedNonce = result.paymentMethod;
+                                                                                   self.progressBlock(@"Ready for checkout...");
+                                                                                   [self updatePaymentMethod:self.selectedNonce];
+                                                                               }
+                                                                               NSLog(@"%@", dropInController);
+                                                                               [dropInController dismissViewControllerAnimated:YES completion:nil];
+                                                                           }];
 
     [self presentViewController:dropIn animated:YES completion:nil];
 }

--- a/UITests/BraintreeDropIn_UITests.swift
+++ b/UITests/BraintreeDropIn_UITests.swift
@@ -967,7 +967,7 @@ class BraintreeDropIn_ThreeDSecure_VaultedPaymentMethod_UITests: XCTestCase {
         app.launchArguments.append("-ClientToken")
         app.launchArguments.append("-ThreeDSecureRequired")
         app.launchArguments.append("-ThreeDSecureVersion2")
-        app.launchArguments.append("-EditModeCustomer")
+        app.launchArguments.append("-CustomerIDWithVaultedPaymentMethods")
         app.launch()
         sleep(1)
         

--- a/UITests/BraintreeDropIn_UITests.swift
+++ b/UITests/BraintreeDropIn_UITests.swift
@@ -839,17 +839,17 @@ class BraintreeDropIn_ThreeDSecure_2_UITests: XCTestCase {
         self.waitForElementToBeHittable(cardNumberTextField)
         cardNumberTextField.typeText("4000000000001000")
 
-        self.waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
+        waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
         app.staticTexts["01"].forceTapElement()
         app.staticTexts[Date.getThreeYearsFromNow()].forceTapElement()
 
         let securityCodeField = elementsQuery.textFields["CVV"]
-        self.waitForElementToBeHittable(securityCodeField)
+        waitForElementToBeHittable(securityCodeField)
         securityCodeField.forceTapElement()
         securityCodeField.typeText("123")
 
         let postalCodeField = elementsQuery.textFields["12345"]
-        self.waitForElementToBeHittable(postalCodeField)
+        waitForElementToBeHittable(postalCodeField)
         postalCodeField.forceTapElement()
         postalCodeField.typeText("12345")
 
@@ -903,11 +903,11 @@ class BraintreeDropIn_ThreeDSecure_2_UITests: XCTestCase {
 
         app.buttons["SUBMIT"].forceTapElement()
 
-        self.waitForElementToAppear(app.staticTexts["ending in 91"])
+        waitForElementToAppear(app.staticTexts["ending in 91"])
 
-        XCTAssertTrue(app.staticTexts["ending in 91"].exists);
+        XCTAssertTrue(app.staticTexts["ending in 91"].exists)
 
-        self.waitForElementToBeHittable(app.buttons["Complete Purchase"])
+        waitForElementToBeHittable(app.buttons["Complete Purchase"])
         app.buttons["Complete Purchase"].forceTapElement()
 
         let existsPredicate = NSPredicate(format: "label LIKE 'created*'")
@@ -952,6 +952,49 @@ class BraintreeDropIn_ThreeDSecure_2_UITests: XCTestCase {
 
         self.waitForElementToAppear(app.buttons["Cancelled🎲"])
         XCTAssertTrue(app.buttons["Cancelled🎲"].exists);
+    }
+}
+
+class BraintreeDropIn_ThreeDSecure_VaultedPaymentMethod_UITests: XCTestCase {
+    
+    var app: XCUIApplication!
+    
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchArguments.append("-EnvironmentSandbox")
+        app.launchArguments.append("-ClientToken")
+        app.launchArguments.append("-ThreeDSecureRequired")
+        app.launchArguments.append("-ThreeDSecureVersion2")
+        app.launchArguments.append("-EditModeCustomer")
+        app.launch()
+        sleep(1)
+        
+        waitForElementToBeHittable(app.buttons["Change Payment Method"])
+        app.buttons["Change Payment Method"].tap()
+    }
+    
+    func testDropIn_threeDSecure_2_challengeFlow_withVaultedPaymentMethod() {
+        waitForElementToBeHittable(app.collectionViews.cells.firstMatch)
+        app.collectionViews.cells.firstMatch.tap()
+        
+        XCTAssertTrue(app.activityIndicators.firstMatch.exists)
+        XCTAssertEqual(0, app.cells.count)
+        
+        waitForElementToAppear(app.staticTexts["Purchase Authentication"], timeout: 20)
+        
+        let textField = app.textFields.element(boundBy: 0)
+        waitForElementToBeHittable(textField)
+        textField.forceTapElement()
+        sleep(2)
+        textField.typeText("1234")
+        
+        app.buttons["SUBMIT"].forceTapElement()
+        
+        waitForElementToAppear(app.staticTexts["ending in 91"])
+        
+        XCTAssertTrue(app.staticTexts["ending in 91"].exists)
     }
 }
 
@@ -1026,7 +1069,7 @@ class BraintreeDropIn_Error_UITests: XCTestCase {
         
         let existsPredicate = NSPredicate(format: "label LIKE '*Application does not support One Touch callback*'")
         
-        self.waitForElementToAppear(app.buttons.containing(existsPredicate).element(boundBy: 0))
+        waitForElementToAppear(app.buttons.containing(existsPredicate).element(boundBy: 0))
     }
 }
 
@@ -1045,10 +1088,10 @@ class BraintreeDropIn_SaveCardToggleVisibleAndOn_UITests: XCTestCase {
         app.launch()
         sleep(1)
 
-        self.waitForElementToBeHittable(app.buttons["Add Payment Method"])
+        waitForElementToBeHittable(app.buttons["Add Payment Method"])
         app.buttons["Add Payment Method"].tap()
 
-        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
         app.staticTexts["Credit or Debit Card"].tap()
     }
 
@@ -1056,11 +1099,11 @@ class BraintreeDropIn_SaveCardToggleVisibleAndOn_UITests: XCTestCase {
         let elementsQuery = app.scrollViews.otherElements
 
         let cardNumberTextField = elementsQuery.textFields["Card Number"]
-        self.waitForElementToBeHittable(cardNumberTextField)
+        waitForElementToBeHittable(cardNumberTextField)
         cardNumberTextField.typeText("4111111111111111")
 
         let saveCardSwitch = elementsQuery.switches["Save card"]
-        self.waitForElementToBeHittable(saveCardSwitch)
+        waitForElementToBeHittable(saveCardSwitch)
 
         XCTAssertTrue(saveCardSwitch.exists)
 
@@ -1085,10 +1128,10 @@ class BraintreeDropIn_SaveCardToggleVisibleAndOff_UITests: XCTestCase {
         app.launch()
         sleep(1)
 
-        self.waitForElementToBeHittable(app.buttons["Add Payment Method"])
+        waitForElementToBeHittable(app.buttons["Add Payment Method"])
         app.buttons["Add Payment Method"].tap()
 
-        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
         app.staticTexts["Credit or Debit Card"].tap()
     }
 
@@ -1096,11 +1139,11 @@ class BraintreeDropIn_SaveCardToggleVisibleAndOff_UITests: XCTestCase {
         let elementsQuery = app.scrollViews.otherElements
 
         let cardNumberTextField = elementsQuery.textFields["Card Number"]
-        self.waitForElementToBeHittable(cardNumberTextField)
+        waitForElementToBeHittable(cardNumberTextField)
         cardNumberTextField.typeText("4111111111111111")
 
         let saveCardSwitch = elementsQuery.switches["Save card"]
-        self.waitForElementToBeHittable(saveCardSwitch)
+        waitForElementToBeHittable(saveCardSwitch)
 
         XCTAssertEqual("0", saveCardSwitch.value as? String)
     }
@@ -1120,10 +1163,10 @@ class BraintreeDropIn_SaveCardToggleHidden_UITests: XCTestCase {
         app.launch()
         sleep(1)
 
-        self.waitForElementToBeHittable(app.buttons["Add Payment Method"])
+        waitForElementToBeHittable(app.buttons["Add Payment Method"])
         app.buttons["Add Payment Method"].tap()
 
-        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
         app.staticTexts["Credit or Debit Card"].tap()
     }
 
@@ -1131,10 +1174,10 @@ class BraintreeDropIn_SaveCardToggleHidden_UITests: XCTestCase {
         let elementsQuery = app.scrollViews.otherElements
 
         let cardNumberTextField = elementsQuery.textFields["Card Number"]
-        self.waitForElementToBeHittable(cardNumberTextField)
+        waitForElementToBeHittable(cardNumberTextField)
         cardNumberTextField.typeText("4111111111111111")
 
-        self.waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
+        waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
 
         let saveCardSwitch = elementsQuery.switches["Save card"]
         XCTAssertFalse(saveCardSwitch.exists)
@@ -1156,10 +1199,10 @@ class BraintreeDropIn_SaveCardToggleHiddenForTokenizationKey_UITests: XCTestCase
         app.launch()
         sleep(1)
 
-        self.waitForElementToBeHittable(app.buttons["Add Payment Method"])
+        waitForElementToBeHittable(app.buttons["Add Payment Method"])
         app.buttons["Add Payment Method"].tap()
 
-        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
         app.staticTexts["Credit or Debit Card"].tap()
     }
 
@@ -1167,10 +1210,10 @@ class BraintreeDropIn_SaveCardToggleHiddenForTokenizationKey_UITests: XCTestCase
         let elementsQuery = app.scrollViews.otherElements
 
         let cardNumberTextField = elementsQuery.textFields["Card Number"]
-        self.waitForElementToBeHittable(cardNumberTextField)
+        waitForElementToBeHittable(cardNumberTextField)
         cardNumberTextField.typeText("4111111111111111")
 
-        self.waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
+        waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
 
         let saveCardSwitch = elementsQuery.switches["Save card"]
         XCTAssertFalse(saveCardSwitch.exists)

--- a/UITests/BraintreeDropIn_UITests.swift
+++ b/UITests/BraintreeDropIn_UITests.swift
@@ -18,83 +18,83 @@ class BraintreeDropIn_TokenizationKey_CardForm_UITests: XCTestCase {
         app.launchArguments.append("-ThreeDSecureDefault")
         app.launch()
         sleep(1)
-        self.waitForElementToBeHittable(app.buttons["Add Payment Method"])
+        waitForElementToBeHittable(app.buttons["Add Payment Method"])
         app.buttons["Add Payment Method"].tap()
     }
     
     func testDropIn_dismissesWhenCancelled() {
-        self.waitForElementToBeHittable(app.buttons["Cancel"])
+        waitForElementToBeHittable(app.buttons["Cancel"])
         app.buttons["Cancel"].forceTapElement()
-        XCTAssertTrue(app.buttons["Cancelled🎲"].exists);
+        XCTAssertTrue(app.buttons["Cancelled🎲"].exists)
     }
     
     func testDropIn_displaysPaymentOptions_applePay_card_payPal() {
-        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
         sleep(1)
-        XCTAssertTrue(app.staticTexts["Credit or Debit Card"].exists);
-        XCTAssertTrue(app.staticTexts["PayPal"].exists);
-        XCTAssertTrue(app.staticTexts["Apple Pay"].exists);
+        XCTAssertTrue(app.staticTexts["Credit or Debit Card"].exists)
+        XCTAssertTrue(app.staticTexts["PayPal"].exists)
+        XCTAssertTrue(app.staticTexts["Apple Pay"].exists)
     }
     
     func testDropIn_cardInput_receivesNonce() {
-        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
         app.staticTexts["Credit or Debit Card"].tap()
         
         let elementsQuery = app.scrollViews.otherElements
         let cardNumberTextField = elementsQuery.textFields["Card Number"]
         
-        self.waitForElementToBeHittable(cardNumberTextField)
+        waitForElementToBeHittable(cardNumberTextField)
         cardNumberTextField.typeText("4111111111111111")
         
-        self.waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
+        waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
         app.staticTexts["11"].forceTapElement()
         app.staticTexts[Date.getNextYear()].forceTapElement()
         
         let securityCodeField = elementsQuery.textFields["CVV"]
-        self.waitForElementToBeHittable(securityCodeField)
+        waitForElementToBeHittable(securityCodeField)
         securityCodeField.forceTapElement()
         securityCodeField.typeText("123")
         
         let postalCodeField = elementsQuery.textFields["12345"]
-        self.waitForElementToBeHittable(postalCodeField)
+        waitForElementToBeHittable(postalCodeField)
         postalCodeField.forceTapElement()
         postalCodeField.typeText("12345")
         
         app.buttons["Add Card"].forceTapElement()
         
-        self.waitForElementToAppear(app.staticTexts["ending in 11"])
+        waitForElementToAppear(app.staticTexts["ending in 11"])
         
-        XCTAssertTrue(app.staticTexts["ending in 11"].exists);
+        XCTAssertTrue(app.staticTexts["ending in 11"].exists)
     }
     
     func testDropIn_cardInput_showsInvalidState_withInvalidCardNumber() {
-        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
         app.staticTexts["Credit or Debit Card"].tap()
         
         let elementsQuery = app.scrollViews.otherElements
         let cardNumberTextField = elementsQuery.textFields["Card Number"]
         
-        self.waitForElementToBeHittable(cardNumberTextField)
+        waitForElementToBeHittable(cardNumberTextField)
         cardNumberTextField.typeText("4141414141414141")
         
-        self.waitForElementToAppear(elementsQuery.staticTexts["You must provide a valid Card Number."])
+        waitForElementToAppear(elementsQuery.staticTexts["You must provide a valid Card Number."])
     }
     
     func testDropIn_cardInput_hidesInvalidCardNumberState_withDeletion() {
-        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
         app.staticTexts["Credit or Debit Card"].tap()
         
         let elementsQuery = app.scrollViews.otherElements
         let cardNumberTextField = elementsQuery.textFields["Card Number"]
         
-        self.waitForElementToBeHittable(cardNumberTextField)
+        waitForElementToBeHittable(cardNumberTextField)
         cardNumberTextField.typeText("4141414141414141")
         
-        self.waitForElementToAppear(elementsQuery.staticTexts["You must provide a valid Card Number."])
+        waitForElementToAppear(elementsQuery.staticTexts["You must provide a valid Card Number."])
         
         cardNumberTextField.typeText("\u{8}")
         
-        XCTAssertFalse(elementsQuery.textFields["Invalid: Card Number"].exists);
+        XCTAssertFalse(elementsQuery.textFields["Invalid: Card Number"].exists)
     }
 }
 
@@ -112,37 +112,37 @@ class BraintreeDropIn_securityCodeValidation_CardForm_UITests: XCTestCase {
         app.launchArguments.append("-Authorization:eyJ2ZXJzaW9uIjoyLCJhdXRob3JpemF0aW9uRmluZ2VycHJpbnQiOiI2ZGE5Y2VhMzVkNGNlMjkxNGI3YzBiOGRiN2M5OWU4MjVmYTQ5ZTY5OTNiYWM4YmE3MTQwYjdiZjI0ODc4NGQ0fGNyZWF0ZWRfYXQ9MjAxOC0wMy0xMlQyMTo0MzoxMS4wOTI1MzAxNDcrMDAwMCZjdXN0b21lcl9pZD01ODA3NDE3NzEmbWVyY2hhbnRfaWQ9aGg0Y3BjMzl6cTRyZ2pjZyZwdWJsaWNfa2V5PXEzanRzcTNkM3Aycmg1dnQiLCJjb25maWdVcmwiOiJodHRwczovL2FwaS5zYW5kYm94LmJyYWludHJlZWdhdGV3YXkuY29tOjQ0My9tZXJjaGFudHMvaGg0Y3BjMzl6cTRyZ2pjZy9jbGllbnRfYXBpL3YxL2NvbmZpZ3VyYXRpb24iLCJncmFwaFFMVXJsIjoiaHR0cHM6Ly9wYXltZW50cy5zYW5kYm94LmJyYWludHJlZS1hcGkuY29tL2dyYXBocWwiLCJjaGFsbGVuZ2VzIjpbImN2diJdLCJlbnZpcm9ubWVudCI6InNhbmRib3giLCJjbGllbnRBcGlVcmwiOiJodHRwczovL2FwaS5zYW5kYm94LmJyYWludHJlZWdhdGV3YXkuY29tOjQ0My9tZXJjaGFudHMvaGg0Y3BjMzl6cTRyZ2pjZy9jbGllbnRfYXBpIiwiYXNzZXRzVXJsIjoiaHR0cHM6Ly9hc3NldHMuYnJhaW50cmVlZ2F0ZXdheS5jb20iLCJhdXRoVXJsIjoiaHR0cHM6Ly9hdXRoLnZlbm1vLnNhbmRib3guYnJhaW50cmVlZ2F0ZXdheS5jb20iLCJhbmFseXRpY3MiOnsidXJsIjoiaHR0cHM6Ly9jbGllbnQtYW5hbHl0aWNzLnNhbmRib3guYnJhaW50cmVlZ2F0ZXdheS5jb20vaGg0Y3BjMzl6cTRyZ2pjZyJ9LCJ0aHJlZURTZWN1cmVFbmFibGVkIjp0cnVlLCJwYXlwYWxFbmFibGVkIjp0cnVlLCJwYXlwYWwiOnsiZGlzcGxheU5hbWUiOiJidCIsImNsaWVudElkIjoiQVZRSmY5YS1iNmptWUZnaW9OcEkyaTU3cnNRa0hqUlpadjRkOURaTFRVMG5CU3Vma2h3QUNBWnhqMGxkdTg1amFzTTAyakZSUEthVElOQ04iLCJwcml2YWN5VXJsIjoiaHR0cDovL2V4YW1wbGUuY29tL3BwIiwidXNlckFncmVlbWVudFVybCI6Imh0dHA6Ly9leGFtcGxlLmNvbS90b3MiLCJiYXNlVXJsIjoiaHR0cHM6Ly9hc3NldHMuYnJhaW50cmVlZ2F0ZXdheS5jb20iLCJhc3NldHNVcmwiOiJodHRwczovL2NoZWNrb3V0LnBheXBhbC5jb20iLCJkaXJlY3RCYXNlVXJsIjpudWxsLCJhbGxvd0h0dHAiOnRydWUsImVudmlyb25tZW50Tm9OZXR3b3JrIjpmYWxzZSwiZW52aXJvbm1lbnQiOiJvZmZsaW5lIiwidW52ZXR0ZWRNZXJjaGFudCI6ZmFsc2UsImJyYWludHJlZUNsaWVudElkIjoibWFzdGVyY2xpZW50MyIsImJpbGxpbmdBZ3JlZW1lbnRzRW5hYmxlZCI6dHJ1ZSwibWVyY2hhbnRBY2NvdW50SWQiOiJjNXljdzJzdnlrbnp3anR6IiwiY3VycmVuY3lJc29Db2RlIjoiVVNEIn0sIm1lcmNoYW50SWQiOiJoaDRjcGMzOXpxNHJnamNnIiwidmVubW8iOiJvZmYiLCJicmFpbnRyZWVfYXBpIjp7InVybCI6Imh0dHBzOi8vcGF5bWVudHMuc2FuZGJveC5icmFpbnRyZWUtYXBpLmNvbSIsImFjY2Vzc190b2tlbiI6InNhbmRib3hfNmRkdG13X3B6YjZ3cF93ZHdoY3lfOWhnNm5iX2N5NiJ9fQ==")
         app.launch()
         sleep(1)
-        self.waitForElementToBeHittable(app.buttons["Change Payment Method"])
+        waitForElementToBeHittable(app.buttons["Change Payment Method"])
         app.buttons["Change Payment Method"].tap()
     }
 
     func testDropIn_invalidSecurityCode_presentsAlert() {
-        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
         app.staticTexts["Credit or Debit Card"].tap()
 
         let elementsQuery = app.scrollViews.otherElements
         let cardNumberTextField = elementsQuery.textFields["Card Number"]
 
-        self.waitForElementToBeHittable(cardNumberTextField)
+        waitForElementToBeHittable(cardNumberTextField)
         cardNumberTextField.typeText("4000000000000002")
 
-        self.waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
+        waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
         app.staticTexts["11"].forceTapElement()
         app.staticTexts[Date.getNextYear()].forceTapElement()
 
         let securityCodeField = elementsQuery.textFields["CVV"]
-        self.waitForElementToBeHittable(securityCodeField)
+        waitForElementToBeHittable(securityCodeField)
         securityCodeField.forceTapElement()
         securityCodeField.typeText("200")
 
         app.buttons["Add Card"].forceTapElement()
 
-        self.waitForElementToBeHittable(app.alerts.buttons["OK"])
-        XCTAssertTrue(app.alerts.staticTexts["Please review your information and try again."].exists);
+        waitForElementToBeHittable(app.alerts.buttons["OK"])
+        XCTAssertTrue(app.alerts.staticTexts["Please review your information and try again."].exists)
         app.alerts.buttons["OK"].tap()
 
         // Assert: can edit after dismissing alert
-        self.waitForElementToBeHittable(securityCodeField)
+        waitForElementToBeHittable(securityCodeField)
         securityCodeField.forceTapElement()
         securityCodeField.typeText("\u{8}1")
     }
@@ -161,13 +161,13 @@ class BraintreeDropIn_CardDisabled_UITests: XCTestCase {
         app.launchArguments.append("-CardDisabled")
         app.launch()
         sleep(1)
-        self.waitForElementToBeHittable(app.buttons["Add Payment Method"])
+        waitForElementToBeHittable(app.buttons["Add Payment Method"])
         app.buttons["Add Payment Method"].tap()
     }
 
     func testDropIn_cardDisabledOption_disablesCreditCard() {
-        XCTAssertTrue(app.staticTexts["PayPal"].exists);
-        XCTAssertFalse(app.staticTexts["Credit or Debit Card"].exists);
+        XCTAssertTrue(app.staticTexts["PayPal"].exists)
+        XCTAssertFalse(app.staticTexts["Credit or Debit Card"].exists)
     }
 }
 
@@ -185,22 +185,22 @@ class BraintreeDropIn_CardForm_RequestOptions_UITests: XCTestCase {
         app.launchArguments.append("-MaskSecurityCode")
         app.launch()
         sleep(1)
-        self.waitForElementToBeHittable(app.buttons["Add Payment Method"])
+        waitForElementToBeHittable(app.buttons["Add Payment Method"])
         app.buttons["Add Payment Method"].tap()
     }
 
     func testDropIn_maskSecurityCodeOption_enablesSecureTextEntry() {
-        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
         app.staticTexts["Credit or Debit Card"].tap()
 
         let elementsQuery = app.scrollViews.otherElements
         let cardNumberTextField = elementsQuery.textFields["Card Number"]
 
-        self.waitForElementToBeHittable(cardNumberTextField)
+        waitForElementToBeHittable(cardNumberTextField)
         cardNumberTextField.typeText("4111111111111111")
 
         let securityCodeField = elementsQuery.secureTextFields["CVV"]
-        self.waitForElementToBeHittable(securityCodeField)
+        waitForElementToBeHittable(securityCodeField)
 
         XCTAssertFalse(elementsQuery.textFields["CVV"].exists)
     }
@@ -219,21 +219,21 @@ class BraintreeDropIn_CardholderNameNotAvailable_UITests: XCTestCase {
         app.launchArguments.append("-ThreeDSecureDefault")
         app.launch()
         sleep(1)
-        self.waitForElementToBeHittable(app.buttons["Add Payment Method"])
+        waitForElementToBeHittable(app.buttons["Add Payment Method"])
         app.buttons["Add Payment Method"].tap()
     }
     
     func testDropIn_cardholderNameNotAvailable_fieldDoesntExist() {
-        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
         app.staticTexts["Credit or Debit Card"].tap()
         
         let elementsQuery = app.scrollViews.otherElements
         let cardNumberTextField = elementsQuery.textFields["Card Number"]
         
-        self.waitForElementToBeHittable(cardNumberTextField)
+        waitForElementToBeHittable(cardNumberTextField)
         cardNumberTextField.typeText("4111111111111111")
         
-        self.waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
+        waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
         
         let cardholderNameField = elementsQuery.textFields["Cardholder Name"]
         XCTAssertFalse(cardholderNameField.exists)
@@ -255,10 +255,10 @@ class BraintreeDropIn_CardholderNameAvailable_UITests: XCTestCase {
         app.launch()
         sleep(1)
         
-        self.waitForElementToBeHittable(app.buttons["Add Payment Method"])
+        waitForElementToBeHittable(app.buttons["Add Payment Method"])
         app.buttons["Add Payment Method"].tap()
         
-        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
         app.staticTexts["Credit or Debit Card"].tap()
     }
     
@@ -266,11 +266,11 @@ class BraintreeDropIn_CardholderNameAvailable_UITests: XCTestCase {
         let elementsQuery = app.scrollViews.otherElements
 
         let cardNumberTextField = elementsQuery.textFields["Card Number"]
-        self.waitForElementToBeHittable(cardNumberTextField)
+        waitForElementToBeHittable(cardNumberTextField)
         cardNumberTextField.typeText("4111111111111111")
         
         let cardholderNameField = elementsQuery.textFields["Cardholder Name"]
-        self.waitForElementToAppear(cardholderNameField)
+        waitForElementToAppear(cardholderNameField)
         XCTAssertTrue(cardholderNameField.exists)
     }
     
@@ -278,31 +278,31 @@ class BraintreeDropIn_CardholderNameAvailable_UITests: XCTestCase {
         let elementsQuery = app.scrollViews.otherElements
 
         let cardNumberTextField = elementsQuery.textFields["Card Number"]
-        self.waitForElementToBeHittable(cardNumberTextField)
+        waitForElementToBeHittable(cardNumberTextField)
         cardNumberTextField.typeText("4111111111111111")
         
         let cardholderNameTextField = elementsQuery.textFields["Cardholder Name"]
         cardholderNameTextField.typeText("\n")
         
-        self.waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
+        waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
         app.staticTexts["11"].forceTapElement()
         app.staticTexts[Date.getNextYear()].forceTapElement()
         
         let securityCodeField = elementsQuery.textFields["CVV"]
-        self.waitForElementToBeHittable(securityCodeField)
+        waitForElementToBeHittable(securityCodeField)
         securityCodeField.forceTapElement()
         securityCodeField.typeText("123")
         
         let postalCodeField = elementsQuery.textFields["12345"]
-        self.waitForElementToBeHittable(postalCodeField)
+        waitForElementToBeHittable(postalCodeField)
         postalCodeField.forceTapElement()
         postalCodeField.typeText("12345")
         
         app.buttons["Add Card"].forceTapElement()
         
-        self.waitForElementToAppear(app.staticTexts["ending in 11"])
+        waitForElementToAppear(app.staticTexts["ending in 11"])
         
-        XCTAssertTrue(app.staticTexts["ending in 11"].exists);
+        XCTAssertTrue(app.staticTexts["ending in 11"].exists)
         
     }
 }
@@ -322,10 +322,10 @@ class BraintreeDropIn_CardholderNameRequired_UITests: XCTestCase {
         app.launch()
         sleep(1)
 
-        self.waitForElementToBeHittable(app.buttons["Add Payment Method"])
+        waitForElementToBeHittable(app.buttons["Add Payment Method"])
         app.buttons["Add Payment Method"].tap()
 
-        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
         app.staticTexts["Credit or Debit Card"].tap()
     }
     
@@ -333,11 +333,11 @@ class BraintreeDropIn_CardholderNameRequired_UITests: XCTestCase {
         let elementsQuery = app.scrollViews.otherElements
 
         let cardNumberTextField = elementsQuery.textFields["Card Number"]
-        self.waitForElementToBeHittable(cardNumberTextField)
+        waitForElementToBeHittable(cardNumberTextField)
         cardNumberTextField.typeText("4111111111111111")
 
         let cardholderNameField = elementsQuery.textFields["Cardholder Name"]
-        self.waitForElementToAppear(cardholderNameField)
+        waitForElementToAppear(cardholderNameField)
 
         XCTAssertTrue(cardholderNameField.exists)
     }
@@ -346,23 +346,23 @@ class BraintreeDropIn_CardholderNameRequired_UITests: XCTestCase {
         let elementsQuery = app.scrollViews.otherElements
 
         let cardNumberTextField = elementsQuery.textFields["Card Number"]
-        self.waitForElementToBeHittable(cardNumberTextField)
+        waitForElementToBeHittable(cardNumberTextField)
         cardNumberTextField.typeText("4111111111111111")
 
         let cardholderNameTextField = elementsQuery.textFields["Cardholder Name"]
         cardholderNameTextField.typeText("\n")
 
-        self.waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
+        waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
         app.staticTexts["11"].forceTapElement()
         app.staticTexts[Date.getNextYear()].forceTapElement()
 
         let securityCodeField = elementsQuery.textFields["CVV"]
-        self.waitForElementToBeHittable(securityCodeField)
+        waitForElementToBeHittable(securityCodeField)
         securityCodeField.forceTapElement()
         securityCodeField.typeText("123")
 
         let postalCodeField = elementsQuery.textFields["12345"]
-        self.waitForElementToBeHittable(postalCodeField)
+        waitForElementToBeHittable(postalCodeField)
         postalCodeField.forceTapElement()
         postalCodeField.typeText("12345")
 
@@ -373,32 +373,32 @@ class BraintreeDropIn_CardholderNameRequired_UITests: XCTestCase {
         let elementsQuery = app.scrollViews.otherElements
 
         let cardNumberTextField = elementsQuery.textFields["Card Number"]
-        self.waitForElementToBeHittable(cardNumberTextField)
+        waitForElementToBeHittable(cardNumberTextField)
         cardNumberTextField.typeText("4111111111111111")
 
         let cardholderNameField = elementsQuery.textFields["Cardholder Name"]
-        self.waitForElementToBeHittable(cardholderNameField)
+        waitForElementToBeHittable(cardholderNameField)
         cardholderNameField.typeText("First Last\n")
 
-        self.waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
+        waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
         app.staticTexts["11"].forceTapElement()
         app.staticTexts[Date.getNextYear()].forceTapElement()
 
         let securityCodeField = elementsQuery.textFields["CVV"]
-        self.waitForElementToBeHittable(securityCodeField)
+        waitForElementToBeHittable(securityCodeField)
         securityCodeField.forceTapElement()
         securityCodeField.typeText("123")
 
         let postalCodeField = elementsQuery.textFields["12345"]
-        self.waitForElementToBeHittable(postalCodeField)
+        waitForElementToBeHittable(postalCodeField)
         postalCodeField.forceTapElement()
         postalCodeField.typeText("12345")
 
         app.buttons["Add Card"].forceTapElement()
 
-        self.waitForElementToAppear(app.staticTexts["ending in 11"])
+        waitForElementToAppear(app.staticTexts["ending in 11"])
 
-        XCTAssertTrue(app.staticTexts["ending in 11"].exists);
+        XCTAssertTrue(app.staticTexts["ending in 11"].exists)
     }
 }
 
@@ -415,92 +415,92 @@ class BraintreeDropIn_ClientToken_CardForm_UITests: XCTestCase {
         app.launchArguments.append("-ThreeDSecureDefault")
         app.launch()
         sleep(1)
-        self.waitForElementToBeHittable(app.buttons["Add Payment Method"])
+        waitForElementToBeHittable(app.buttons["Add Payment Method"])
         app.buttons["Add Payment Method"].tap()
     }
     
     func testDropIn_cardInput_receivesNonce() {
-        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
         app.staticTexts["Credit or Debit Card"].tap()
         
         let elementsQuery = app.scrollViews.otherElements
         let cardNumberTextField = elementsQuery.textFields["Card Number"]
         
-        self.waitForElementToBeHittable(cardNumberTextField)
+        waitForElementToBeHittable(cardNumberTextField)
         cardNumberTextField.typeText("4111111111111111")
-        self.waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
+        waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
         app.staticTexts["11"].forceTapElement()
         app.staticTexts[Date.getNextYear()].forceTapElement()
         
         let securityCodeField = app.scrollViews.otherElements.textFields["CVV"]
-        self.waitForElementToBeHittable(securityCodeField)
+        waitForElementToBeHittable(securityCodeField)
         securityCodeField.forceTapElement()
         securityCodeField.typeText("123")
         
         let postalCodeField = app.scrollViews.otherElements.textFields["12345"]
-        self.waitForElementToBeHittable(postalCodeField)
+        waitForElementToBeHittable(postalCodeField)
         postalCodeField.forceTapElement()
         postalCodeField.typeText("12345")
         
         app.buttons["Add Card"].forceTapElement()
         
-        self.waitForElementToAppear(app.staticTexts["ending in 11"])
+        waitForElementToAppear(app.staticTexts["ending in 11"])
         
-        XCTAssertTrue(app.staticTexts["ending in 11"].exists);
+        XCTAssertTrue(app.staticTexts["ending in 11"].exists)
     }
     
     func testDropIn_nonUnionPayCardNumber_showsNextButton() {
-        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
         app.staticTexts["Credit or Debit Card"].tap()
         
         XCTAssertTrue(app.buttons["Next"].exists)
     }
     
     func testDropIn_hidesValidateButtonAfterCardNumberEntered() {
-        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
         app.staticTexts["Credit or Debit Card"].tap()
         
         let elementsQuery = app.scrollViews.otherElements
         let cardNumberTextField = elementsQuery.textFields["Card Number"]
         
-        self.waitForElementToBeHittable(cardNumberTextField)
+        waitForElementToBeHittable(cardNumberTextField)
         cardNumberTextField.typeText("4111111111111111")
         
         XCTAssertFalse(app.buttons["Next"].exists)
     }
     
     func pendDropIn_showsSpinnerDuringUnionPayCapabilitiesFetch() {
-        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
         app.staticTexts["Credit or Debit Card"].tap()
         
         let elementsQuery = app.scrollViews.otherElements
         let cardNumberTextField = elementsQuery.textFields["Card Number"]
         
-        self.waitForElementToBeHittable(cardNumberTextField)
+        waitForElementToBeHittable(cardNumberTextField)
         cardNumberTextField.typeText("6212345678901232")
         
-        self.waitForElementToBeHittable(app.buttons["Next"])
+        waitForElementToBeHittable(app.buttons["Next"])
         app.buttons["Next"].forceTapElement()
         XCTAssertTrue(app.activityIndicators.count == 1 && app.activityIndicators["In progress"].exists)
     }
     
     func pendDropIn_unionPayCardNumber_receivesNonce() {
-        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
         app.staticTexts["Credit or Debit Card"].tap()
         
         let elementsQuery = app.scrollViews.otherElements
         let cardNumberTextField = elementsQuery.textFields["Card Number"]
         
-        self.waitForElementToBeHittable(cardNumberTextField)
+        waitForElementToBeHittable(cardNumberTextField)
         cardNumberTextField.typeText("6212345678901232")
         
-        self.waitForElementToBeHittable(app.buttons["Next"])
+        waitForElementToBeHittable(app.buttons["Next"])
         app.buttons["Next"].forceTapElement()
         
         let expiryTextField = elementsQuery.textFields["MM/YYYY"]
-        self.waitForElementToBeHittable(expiryTextField)
+        waitForElementToBeHittable(expiryTextField)
         
-        self.waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
+        waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
         app.staticTexts["11"].forceTapElement()
         app.staticTexts[Date.getNextYear()].forceTapElement()
         
@@ -512,31 +512,31 @@ class BraintreeDropIn_ClientToken_CardForm_UITests: XCTestCase {
         
         app.buttons["Add Card"].forceTapElement()
         
-        self.waitForElementToBeHittable(app.alerts.buttons["OK"])
+        waitForElementToBeHittable(app.alerts.buttons["OK"])
         app.alerts.buttons["OK"].tap()
         
-        self.waitForElementToBeHittable(app.textFields["SMS Code"])
+        waitForElementToBeHittable(app.textFields["SMS Code"])
         app.textFields["SMS Code"].forceTapElement()
         app.typeText("12345")
         
-        self.waitForElementToBeHittable(app.buttons["Confirm"])
+        waitForElementToBeHittable(app.buttons["Confirm"])
         app.buttons["Confirm"].forceTapElement()
         
-        self.waitForElementToAppear(app.staticTexts["ending in 32"])
+        waitForElementToAppear(app.staticTexts["ending in 32"])
         
-        XCTAssertTrue(app.staticTexts["ending in 32"].exists);
+        XCTAssertTrue(app.staticTexts["ending in 32"].exists)
     }
     
     func testDropIn_cardInput_doesNotShowCardIOButton_inSimulator() {
-        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
         app.staticTexts["Credit or Debit Card"].tap()
         
         let elementsQuery = app.scrollViews.otherElements
         let cardNumberTextField = elementsQuery.textFields["Card Number"]
         
-        self.waitForElementToBeHittable(cardNumberTextField)
+        waitForElementToBeHittable(cardNumberTextField)
         cardNumberTextField.typeText("4111111111111111")
-        XCTAssertFalse(app.staticTexts["Scan with card.io"].exists);
+        XCTAssertFalse(app.staticTexts["Scan with card.io"].exists)
     }
 }
 
@@ -553,13 +553,13 @@ class BraintreeDropIn_PayPal_UITests: XCTestCase {
         app.launchArguments.append("-TokenizationKey")
         app.launch()
         sleep(1)
-        self.waitForElementToBeHittable(app.buttons["Add Payment Method"])
+        waitForElementToBeHittable(app.buttons["Add Payment Method"])
         app.buttons["Add Payment Method"].tap()
     }
     
     func testDropIn_paypal_showsPayPal() {
-        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
-        XCTAssertTrue(app.staticTexts["PayPal"].exists);
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        XCTAssertTrue(app.staticTexts["PayPal"].exists)
     }
     
     func testDropIn_paypal_receivesNonce() {
@@ -568,17 +568,17 @@ class BraintreeDropIn_PayPal_UITests: XCTestCase {
             return
         }
         
-        self.waitForElementToBeHittable(app.staticTexts["PayPal"])
+        waitForElementToBeHittable(app.staticTexts["PayPal"])
         app.staticTexts["PayPal"].tap()
         sleep(3)
         
         let webviewElementsQuery = app.webViews.element.otherElements
         
-        self.waitForElementToBeHittable(webviewElementsQuery.links["Proceed with Sandbox Purchase"])
+        waitForElementToBeHittable(webviewElementsQuery.links["Proceed with Sandbox Purchase"])
         
         webviewElementsQuery.links["Proceed with Sandbox Purchase"].forceTapElement()
         
-        self.waitForElementToAppear(app.staticTexts["bt_buyer_us@paypal.com"])
+        waitForElementToAppear(app.staticTexts["bt_buyer_us@paypal.com"])
         
         XCTAssertTrue(app.staticTexts["bt_buyer_us@paypal.com"].exists)
     }
@@ -588,17 +588,17 @@ class BraintreeDropIn_PayPal_UITests: XCTestCase {
             return
         }
 
-        self.waitForElementToBeHittable(app.staticTexts["PayPal"])
+        waitForElementToBeHittable(app.staticTexts["PayPal"])
         app.staticTexts["PayPal"].tap()
         sleep(3)
 
         let webviewElementsQuery = app.webViews.element.otherElements
 
-        self.waitForElementToBeHittable(webviewElementsQuery.links["Cancel Sandbox Purchase"])
+        waitForElementToBeHittable(webviewElementsQuery.links["Cancel Sandbox Purchase"])
 
         webviewElementsQuery.links["Cancel Sandbox Purchase"].forceTapElement()
 
-        self.waitForElementToAppear(app.staticTexts["Select Payment Method"])
+        waitForElementToAppear(app.staticTexts["Select Payment Method"])
 
         XCTAssertTrue(app.staticTexts["Select Payment Method"].exists)
     }
@@ -617,7 +617,7 @@ class BraintreeDropIn_PayPal_OneTime_UITests: XCTestCase {
         app.launchArguments.append("-TokenizationKey")
         app.launch()
         sleep(1)
-        self.waitForElementToBeHittable(app.buttons["Add Payment Method"])
+        waitForElementToBeHittable(app.buttons["Add Payment Method"])
         app.buttons["Add Payment Method"].tap()
     }
 
@@ -627,19 +627,19 @@ class BraintreeDropIn_PayPal_OneTime_UITests: XCTestCase {
             return
         }
 
-        self.waitForElementToBeHittable(app.staticTexts["PayPal"])
+        waitForElementToBeHittable(app.staticTexts["PayPal"])
         app.staticTexts["PayPal"].tap()
         sleep(3)
 
         let webviewElementsQuery = app.webViews.element.otherElements
 
-        self.waitForElementToAppear(webviewElementsQuery.staticTexts["4.77"])
+        waitForElementToAppear(webviewElementsQuery.staticTexts["4.77"])
 
-        self.waitForElementToBeHittable(webviewElementsQuery.links["Proceed with Sandbox Purchase"])
+        waitForElementToBeHittable(webviewElementsQuery.links["Proceed with Sandbox Purchase"])
 
         webviewElementsQuery.links["Proceed with Sandbox Purchase"].forceTapElement()
 
-        self.waitForElementToAppear(app.staticTexts["bt_buyer_us@paypal.com"])
+        waitForElementToAppear(app.staticTexts["bt_buyer_us@paypal.com"])
 
         XCTAssertTrue(app.staticTexts["bt_buyer_us@paypal.com"].exists)
     }
@@ -658,13 +658,13 @@ class BraintreeDropIn_PayPal_Disabled_UITests: XCTestCase {
         app.launchArguments.append("-DisablePayPal")
         app.launch()
         sleep(1)
-        self.waitForElementToBeHittable(app.buttons["Add Payment Method"])
+        waitForElementToBeHittable(app.buttons["Add Payment Method"])
         app.buttons["Add Payment Method"].tap()
     }
     
     func testDropIn_paypal_doesNotShowPayPal_whenDisabled() {
-        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
-        XCTAssertFalse(app.staticTexts["PayPal"].exists);
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        XCTAssertFalse(app.staticTexts["PayPal"].exists)
     }
 }
 
@@ -682,129 +682,129 @@ class BraintreeDropIn_ThreeDSecure_UITests: XCTestCase {
         app.launchArguments.append("-ThreeDSecureVersionLegacy")
         app.launch()
         sleep(1)
-        self.waitForElementToBeHittable(app.buttons["Add Payment Method"])
+        waitForElementToBeHittable(app.buttons["Add Payment Method"])
         app.buttons["Add Payment Method"].tap()
     }
     
     func testDropIn_threeDSecure_showsThreeDSecureWebview_andTransacts() {
-        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
         app.staticTexts["Credit or Debit Card"].tap()
         
         let elementsQuery = app.scrollViews.otherElements
         let cardNumberTextField = elementsQuery.textFields["Card Number"]
         
-        self.waitForElementToBeHittable(cardNumberTextField)
+        waitForElementToBeHittable(cardNumberTextField)
         cardNumberTextField.typeText("4111111111111111")
         
-        self.waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
+        waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
         app.staticTexts["11"].forceTapElement()
         app.staticTexts[Date.getNextYear()].forceTapElement()
         
         let securityCodeField = elementsQuery.textFields["CVV"]
-        self.waitForElementToBeHittable(securityCodeField)
+        waitForElementToBeHittable(securityCodeField)
         securityCodeField.forceTapElement()
         securityCodeField.typeText("123")
         
         let postalCodeField = elementsQuery.textFields["12345"]
-        self.waitForElementToBeHittable(postalCodeField)
+        waitForElementToBeHittable(postalCodeField)
         postalCodeField.forceTapElement()
         postalCodeField.typeText("12345")
         
         app.buttons["Add Card"].forceTapElement()
         
-        self.waitForElementToAppear(app.staticTexts["Added Protection"], timeout: 20)
+        waitForElementToAppear(app.staticTexts["Added Protection"], timeout: 20)
         
         let textField = app.secureTextFields.element(boundBy: 0)
-        self.waitForElementToBeHittable(textField)
+        waitForElementToBeHittable(textField)
         textField.forceTapElement()
         sleep(2)
         textField.typeText("1234")
         
         app.buttons["Submit"].forceTapElement()
         
-        self.waitForElementToAppear(app.staticTexts["ending in 11"])
+        waitForElementToAppear(app.staticTexts["ending in 11"])
         
-        XCTAssertTrue(app.staticTexts["ending in 11"].exists);
+        XCTAssertTrue(app.staticTexts["ending in 11"].exists)
         
-        self.waitForElementToBeHittable(app.buttons["Complete Purchase"])
+        waitForElementToBeHittable(app.buttons["Complete Purchase"])
         app.buttons["Complete Purchase"].forceTapElement()
         
         let existsPredicate = NSPredicate(format: "label LIKE 'created*'")
         
-        self.waitForElementToAppear(app.buttons.containing(existsPredicate).element(boundBy: 0))
+        waitForElementToAppear(app.buttons.containing(existsPredicate).element(boundBy: 0))
     }
 
     func testDropIn_threeDSecure_returnsToPaymentSelectionView_whenCanceled() {
-        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
         app.staticTexts["Credit or Debit Card"].tap()
         
         let elementsQuery = app.scrollViews.otherElements
         let cardNumberTextField = elementsQuery.textFields["Card Number"]
         
-        self.waitForElementToBeHittable(cardNumberTextField)
+        waitForElementToBeHittable(cardNumberTextField)
         cardNumberTextField.typeText("4111111111111111")
         
-        self.waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
+        waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
         app.staticTexts["11"].forceTapElement()
         app.staticTexts[Date.getNextYear()].forceTapElement()
         
         let securityCodeField = elementsQuery.textFields["CVV"]
-        self.waitForElementToBeHittable(securityCodeField)
+        waitForElementToBeHittable(securityCodeField)
         securityCodeField.forceTapElement()
         securityCodeField.typeText("123")
         
         let postalCodeField = elementsQuery.textFields["12345"]
-        self.waitForElementToBeHittable(postalCodeField)
+        waitForElementToBeHittable(postalCodeField)
         postalCodeField.forceTapElement()
         postalCodeField.typeText("12345")
         
         app.buttons["Add Card"].forceTapElement()
         
-        self.waitForElementToAppear(app.staticTexts["Added Protection"], timeout: 20)
+        waitForElementToAppear(app.staticTexts["Added Protection"], timeout: 20)
         
         app.buttons["Done"].forceTapElement()
-        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
-        self.waitForElementToAppear(app.staticTexts["Select Payment Method"])
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        waitForElementToAppear(app.staticTexts["Select Payment Method"])
 
-        self.waitForElementToBeHittable(app.buttons["Cancel"])
+        waitForElementToBeHittable(app.buttons["Cancel"])
         app.buttons["Cancel"].forceTapElement()
 
-        self.waitForElementToAppear(app.buttons["Cancelled🎲"])
-        XCTAssertTrue(app.buttons["Cancelled🎲"].exists);
+        waitForElementToAppear(app.buttons["Cancelled🎲"])
+        XCTAssertTrue(app.buttons["Cancelled🎲"].exists)
     }
     
     func testDropIn_threeDSecure_tokenizationError_showsAlert() {
-        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
         app.staticTexts["Credit or Debit Card"].tap()
         
         let elementsQuery = app.scrollViews.otherElements
         let cardNumberTextField = elementsQuery.textFields["Card Number"]
         
-        self.waitForElementToBeHittable(cardNumberTextField)
+        waitForElementToBeHittable(cardNumberTextField)
         cardNumberTextField.typeText("4687380000000008")
         
-        self.waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
+        waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
         app.staticTexts["01"].forceTapElement()
         app.staticTexts[Date.getNextYear()].forceTapElement()
         
         let securityCodeField = elementsQuery.textFields["CVV"]
-        self.waitForElementToBeHittable(securityCodeField)
+        waitForElementToBeHittable(securityCodeField)
         securityCodeField.forceTapElement()
         securityCodeField.typeText("200")
         
         let postalCodeField = elementsQuery.textFields["12345"]
-        self.waitForElementToBeHittable(postalCodeField)
+        waitForElementToBeHittable(postalCodeField)
         postalCodeField.forceTapElement()
         postalCodeField.typeText("12345")
         
         app.buttons["Add Card"].forceTapElement()
         
-        self.waitForElementToBeHittable(app.alerts.buttons["OK"])
+        waitForElementToBeHittable(app.alerts.buttons["OK"])
         XCTAssertTrue(app.alerts.staticTexts["Please review your information and try again."].exists)
         app.alerts.buttons["OK"].tap()
         
         // Assert: can edit after dismissing alert
-        self.waitForElementToBeHittable(securityCodeField)
+        waitForElementToBeHittable(securityCodeField)
         securityCodeField.forceTapElement()
         securityCodeField.typeText("\u{8}1")
     }
@@ -825,18 +825,18 @@ class BraintreeDropIn_ThreeDSecure_2_UITests: XCTestCase {
         app.launch()
         sleep(1)
 
-        self.waitForElementToBeHittable(app.buttons["Add Payment Method"])
+        waitForElementToBeHittable(app.buttons["Add Payment Method"])
         app.buttons["Add Payment Method"].tap()
     }
 
     func testDropIn_threeDSecure_2_frictionlessFlow_andTransacts() {
-        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
         app.staticTexts["Credit or Debit Card"].tap()
 
         let elementsQuery = app.scrollViews.otherElements
         let cardNumberTextField = elementsQuery.textFields["Card Number"]
 
-        self.waitForElementToBeHittable(cardNumberTextField)
+        waitForElementToBeHittable(cardNumberTextField)
         cardNumberTextField.typeText("4000000000001000")
 
         waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
@@ -855,48 +855,48 @@ class BraintreeDropIn_ThreeDSecure_2_UITests: XCTestCase {
 
         app.buttons["Add Card"].forceTapElement()
 
-        self.waitForElementToAppear(app.staticTexts["ending in 00"])
+        waitForElementToAppear(app.staticTexts["ending in 00"])
 
-        XCTAssertTrue(app.staticTexts["ending in 00"].exists);
+        XCTAssertTrue(app.staticTexts["ending in 00"].exists)
 
-        self.waitForElementToBeHittable(app.buttons["Complete Purchase"])
+        waitForElementToBeHittable(app.buttons["Complete Purchase"])
         app.buttons["Complete Purchase"].forceTapElement()
 
         let existsPredicate = NSPredicate(format: "label LIKE 'created*'")
 
-        self.waitForElementToAppear(app.buttons.containing(existsPredicate).element(boundBy: 0))
+        waitForElementToAppear(app.buttons.containing(existsPredicate).element(boundBy: 0))
     }
 
     func testDropIn_threeDSecure_2_challengeFlow_andTransacts() {
-        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
         app.staticTexts["Credit or Debit Card"].tap()
 
         let elementsQuery = app.scrollViews.otherElements
         let cardNumberTextField = elementsQuery.textFields["Card Number"]
 
-        self.waitForElementToBeHittable(cardNumberTextField)
+        waitForElementToBeHittable(cardNumberTextField)
         cardNumberTextField.typeText("4000000000001091")
 
-        self.waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
+        waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
         app.staticTexts["01"].forceTapElement()
         app.staticTexts[Date.getThreeYearsFromNow()].forceTapElement()
 
         let securityCodeField = elementsQuery.textFields["CVV"]
-        self.waitForElementToBeHittable(securityCodeField)
+        waitForElementToBeHittable(securityCodeField)
         securityCodeField.forceTapElement()
         securityCodeField.typeText("123")
 
         let postalCodeField = elementsQuery.textFields["12345"]
-        self.waitForElementToBeHittable(postalCodeField)
+        waitForElementToBeHittable(postalCodeField)
         postalCodeField.forceTapElement()
         postalCodeField.typeText("12345")
 
         app.buttons["Add Card"].forceTapElement()
 
-        self.waitForElementToAppear(app.staticTexts["Purchase Authentication"], timeout: 20)
+        waitForElementToAppear(app.staticTexts["Purchase Authentication"], timeout: 20)
 
         let textField = app.textFields.element(boundBy: 0)
-        self.waitForElementToBeHittable(textField)
+        waitForElementToBeHittable(textField)
         textField.forceTapElement()
         sleep(2)
         textField.typeText("1234")
@@ -912,46 +912,46 @@ class BraintreeDropIn_ThreeDSecure_2_UITests: XCTestCase {
 
         let existsPredicate = NSPredicate(format: "label LIKE 'created*'")
 
-        self.waitForElementToAppear(app.buttons.containing(existsPredicate).element(boundBy: 0))
+        waitForElementToAppear(app.buttons.containing(existsPredicate).element(boundBy: 0))
     }
 
     func testDropIn_threeDSecure_2_returnsToPaymentSelectionView_whenCanceled() {
-        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
         app.staticTexts["Credit or Debit Card"].tap()
 
         let elementsQuery = app.scrollViews.otherElements
         let cardNumberTextField = elementsQuery.textFields["Card Number"]
 
-        self.waitForElementToBeHittable(cardNumberTextField)
+        waitForElementToBeHittable(cardNumberTextField)
         cardNumberTextField.typeText("4000000000001091")
 
-        self.waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
+        waitForElementToBeHittable(app.staticTexts[Date.getNextYear()])
         app.staticTexts["01"].forceTapElement()
         app.staticTexts[Date.getThreeYearsFromNow()].forceTapElement()
 
         let securityCodeField = elementsQuery.textFields["CVV"]
-        self.waitForElementToBeHittable(securityCodeField)
+        waitForElementToBeHittable(securityCodeField)
         securityCodeField.forceTapElement()
         securityCodeField.typeText("123")
 
         let postalCodeField = elementsQuery.textFields["12345"]
-        self.waitForElementToBeHittable(postalCodeField)
+        waitForElementToBeHittable(postalCodeField)
         postalCodeField.forceTapElement()
         postalCodeField.typeText("12345")
 
         app.buttons["Add Card"].forceTapElement()
 
-        self.waitForElementToAppear(app.staticTexts["Purchase Authentication"], timeout: 20)
+        waitForElementToAppear(app.staticTexts["Purchase Authentication"], timeout: 20)
 
         app.buttons["Cancel"].forceTapElement()
-        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
-        self.waitForElementToAppear(app.staticTexts["Select Payment Method"])
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        waitForElementToAppear(app.staticTexts["Select Payment Method"])
 
-        self.waitForElementToBeHittable(app.buttons["Cancel"])
+        waitForElementToBeHittable(app.buttons["Cancel"])
         app.buttons["Cancel"].forceTapElement()
 
-        self.waitForElementToAppear(app.buttons["Cancelled🎲"])
-        XCTAssertTrue(app.buttons["Cancelled🎲"].exists);
+        waitForElementToAppear(app.buttons["Cancelled🎲"])
+        XCTAssertTrue(app.buttons["Cancelled🎲"].exists)
     }
 }
 
@@ -1012,13 +1012,13 @@ class BraintreeDropIn_Venmo_Disabled_UITests: XCTestCase {
         app.launchArguments.append("-DisableVenmo")
         app.launch()
         sleep(1)
-        self.waitForElementToBeHittable(app.buttons["Add Payment Method"])
+        waitForElementToBeHittable(app.buttons["Add Payment Method"])
         app.buttons["Add Payment Method"].tap()
     }
     
     func testDropIn_venmo_doesNotShow_whenDisabled() {
-        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
-        XCTAssertFalse(app.staticTexts["Venmo"].exists);
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        XCTAssertFalse(app.staticTexts["Venmo"].exists)
     }
 }
 
@@ -1035,13 +1035,13 @@ class BraintreeDropIn_Venmo_UITests: XCTestCase {
         app.launchArguments.append("-ForceVenmo")
         app.launch()
         sleep(1)
-        self.waitForElementToBeHittable(app.buttons["Add Payment Method"])
+        waitForElementToBeHittable(app.buttons["Add Payment Method"])
         app.buttons["Add Payment Method"].tap()
     }
     
     func testDropIn_venmo_doesShow() {
-        self.waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
-        XCTAssertTrue(app.staticTexts["Venmo"].exists);
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        XCTAssertTrue(app.staticTexts["Venmo"].exists)
     }
 }
 
@@ -1058,12 +1058,12 @@ class BraintreeDropIn_Error_UITests: XCTestCase {
         app.launchArguments.append("-BadUrlScheme")
         app.launch()
         sleep(1)
-        self.waitForElementToBeHittable(app.buttons["Add Payment Method"])
+        waitForElementToBeHittable(app.buttons["Add Payment Method"])
         app.buttons["Add Payment Method"].tap()
     }
     
     func testDropIn_paypal_receivesError_whenUrlSchemeIsIncorrect() {
-        self.waitForElementToBeHittable(app.staticTexts["PayPal"])
+        waitForElementToBeHittable(app.staticTexts["PayPal"])
         app.staticTexts["PayPal"].tap()
         sleep(3)
         

--- a/UITests/BraintreeDropinEditMode_UITests.swift
+++ b/UITests/BraintreeDropinEditMode_UITests.swift
@@ -14,7 +14,7 @@ class BraintreeDropIn_EditMode_UITests: XCTestCase {
         continueAfterFailure = false
         app = XCUIApplication()
         app.launchArguments.append("-EnvironmentSandbox")
-        app.launchArguments.append("-EditModeCustomer")
+        app.launchArguments.append("-CustomerIDWithVaultedPaymentMethods")
         app.launchArguments.append("-ClientToken")
         app.launch()
         sleep(1)
@@ -50,7 +50,7 @@ class BraintreeDropIn_EditMode_Disabled_UITests: XCTestCase {
         continueAfterFailure = false
         app = XCUIApplication()
         app.launchArguments.append("-EnvironmentSandbox")
-        app.launchArguments.append("-EditModeCustomer")
+        app.launchArguments.append("-CustomerIDWithVaultedPaymentMethods")
         app.launchArguments.append("-DisableEditMode")
         app.launchArguments.append("-ClientToken")
         app.launch()


### PR DESCRIPTION
### Summary of changes

 - Show an activity indicator when a 3DS flow is triggered by the user selecting a vaulted payment method. This prevents the user from tapping on the vaulted payment method multiple times, which caused the 3DS flow to fail b/c lookup was performed multiple times for the same nonce.
- Clean up semicolons and `self` in BraintreeDropIn_UITests. **NOTE:** This is a separate commit, and it might be easier to review it separately since there are a lot of small changes.

 ### Checklist

 - [x] Added a changelog entry
