### PR TITLE
Update sdk dependency

### DIFF
--- a/BraintreeDropIn.podspec
+++ b/BraintreeDropIn.podspec
@@ -27,11 +27,11 @@ Pod::Spec.new do |s|
     s.source_files  = "BraintreeDropIn/**/*.{h,m}"
     s.public_header_files = "BraintreeDropIn/Public/*.h"
     s.frameworks = "UIKit"
-    s.dependency "Braintree/Card", "~> 4.27"
-    s.dependency "Braintree/Core", "~> 4.27"
-    s.dependency "Braintree/UnionPay", "~> 4.27"
-    s.dependency "Braintree/PaymentFlow", "~> 4.27"
-    s.dependency "Braintree/PayPal", "~> 4.27"
+    s.dependency "Braintree/Card", "~> 4.29"
+    s.dependency "Braintree/Core", "~> 4.29"
+    s.dependency "Braintree/UnionPay", "~> 4.29"
+    s.dependency "Braintree/PaymentFlow", "~> 4.29"
+    s.dependency "Braintree/PayPal", "~> 4.29"
     s.dependency "BraintreeDropIn/UIKit"
   end
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS Drop-in SDK - Release Notes
 
+## Unreleased
+
+* Require Braintree ~> 4.29
+
 ## 7.4.0 (2019-08-29)
 
 * Deprecate `amount` property on `BTDropInRequest`

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -14,42 +14,42 @@ PODS:
   - AFNetworking/Serialization (3.2.1)
   - AFNetworking/UIKit (3.2.1):
     - AFNetworking/NSURLSession
-  - Braintree/Apple-Pay (4.27.0):
+  - Braintree/Apple-Pay (4.29.0):
     - Braintree/Core
-  - Braintree/Card (4.27.0):
+  - Braintree/Card (4.29.0):
     - Braintree/Core
-  - Braintree/Core (4.27.0)
-  - Braintree/PaymentFlow (4.27.0):
+  - Braintree/Core (4.29.0)
+  - Braintree/PaymentFlow (4.29.0):
     - Braintree/Card
     - Braintree/Core
     - Braintree/PayPalOneTouch
-  - Braintree/PayPal (4.27.0):
+  - Braintree/PayPal (4.29.0):
     - Braintree/Core
     - Braintree/PayPalOneTouch
-  - Braintree/PayPalDataCollector (4.27.0):
+  - Braintree/PayPalDataCollector (4.29.0):
     - Braintree/Core
     - Braintree/PayPalUtils
-  - Braintree/PayPalOneTouch (4.27.0):
+  - Braintree/PayPalOneTouch (4.29.0):
     - Braintree/Core
     - Braintree/PayPalDataCollector
     - Braintree/PayPalUtils
-  - Braintree/PayPalUtils (4.27.0)
-  - Braintree/UnionPay (4.27.0):
+  - Braintree/PayPalUtils (4.29.0)
+  - Braintree/UnionPay (4.29.0):
     - Braintree/Card
     - Braintree/Core
-  - Braintree/Venmo (4.27.0):
+  - Braintree/Venmo (4.29.0):
     - Braintree/Core
     - Braintree/PayPalDataCollector
-  - BraintreeDropIn (7.3.0):
-    - BraintreeDropIn/DropIn (= 7.3.0)
-  - BraintreeDropIn/DropIn (7.3.0):
-    - Braintree/Card (~> 4.27)
-    - Braintree/Core (~> 4.27)
-    - Braintree/PaymentFlow (~> 4.27)
-    - Braintree/PayPal (~> 4.27)
-    - Braintree/UnionPay (~> 4.27)
+  - BraintreeDropIn (7.4.0):
+    - BraintreeDropIn/DropIn (= 7.4.0)
+  - BraintreeDropIn/DropIn (7.4.0):
+    - Braintree/Card (~> 4.29)
+    - Braintree/Core (~> 4.29)
+    - Braintree/PaymentFlow (~> 4.29)
+    - Braintree/PayPal (~> 4.29)
+    - Braintree/UnionPay (~> 4.29)
     - BraintreeDropIn/UIKit
-  - BraintreeDropIn/UIKit (7.3.0)
+  - BraintreeDropIn/UIKit (7.4.0)
   - CardIO (5.4.1)
   - Expecta (1.0.6)
   - InAppSettingsKit (2.12)
@@ -86,7 +86,7 @@ DEPENDENCIES:
   - Specta
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - AFNetworking
     - Braintree
     - CardIO
@@ -103,8 +103,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AFNetworking: b6f891fdfaed196b46c7a83cf209e09697b94057
-  Braintree: 981b1e669af6862e1d5b2dbb5c4a6d8d33a11907
-  BraintreeDropIn: 0a946f87a60efed56189b02416915a6d9ee8c1d6
+  Braintree: c8276bc46657026116971442f9de194e028f4fbb
+  BraintreeDropIn: 54f86beb0f776fdadc4b0918ad130cdbf1946764
   CardIO: 56983b39b62f495fc6dae9ad7cf875143df06443
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   InAppSettingsKit: 363ed5ea061ebcb76d69ca1eed08c8a4fe48baf2
@@ -115,4 +115,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 07e21b0fdaccd1950a97f88cf78d4a7ead3db17d
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.8.0


### PR DESCRIPTION
Updated minimum Braintree SDK requirement to 4.29