### PR TITLE
Clarify 3DS Transaction Setting in Demo App

### DIFF
--- a/BraintreeDropIn.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
+++ b/BraintreeDropIn.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
@@ -23,8 +23,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -36,8 +34,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/DropInDemo/Demo Base/DemoAppDelegate.swift
+++ b/DropInDemo/Demo Base/DemoAppDelegate.swift
@@ -40,7 +40,7 @@ class DemoAppDelegate: UIResponder, UIApplicationDelegate {
         if testArguments.contains("-ThreeDSecureRequired") {
             UserDefaults.standard.set(DemoThreeDSecureRequiredSetting.required.rawValue, forKey:DemoSettings.ThreeDSecureRequiredDefaultsKey)
         } else if testArguments.contains("-ThreeDSecureDefault") {
-            UserDefaults.standard.set(DemoThreeDSecureRequiredSetting.requiredIfPresent.rawValue, forKey:DemoSettings.ThreeDSecureRequiredDefaultsKey)
+            UserDefaults.standard.set(DemoThreeDSecureRequiredSetting.requiredIfAttempted.rawValue, forKey:DemoSettings.ThreeDSecureRequiredDefaultsKey)
         }
         
         if testArguments.contains("-ThreeDSecureVersion2") {

--- a/DropInDemo/Demo Base/Settings/DemoSettings.swift
+++ b/DropInDemo/Demo Base/Settings/DemoSettings.swift
@@ -9,9 +9,9 @@ enum DemoEnvironment: Int {
 
 @objc
 enum DemoThreeDSecureRequiredSetting: Int {
-    case requiredIfPresent
+    case requiredIfAttempted
     case required
-    case notRequired
+    case optional
 }
 
 @objc
@@ -68,7 +68,7 @@ class DemoSettings: NSObject {
     
     @objc
     static var threeDSecureRequiredStatus: DemoThreeDSecureRequiredSetting {
-        return DemoThreeDSecureRequiredSetting(rawValue: UserDefaults.standard.integer(forKey: ThreeDSecureRequiredDefaultsKey)) ?? .requiredIfPresent
+        return DemoThreeDSecureRequiredSetting(rawValue: UserDefaults.standard.integer(forKey: ThreeDSecureRequiredDefaultsKey)) ?? .requiredIfAttempted
     }
     
     @objc

--- a/DropInDemo/Demo Base/Settings/Settings.bundle/Root.plist
+++ b/DropInDemo/Demo Base/Settings/Settings.bundle/Root.plist
@@ -85,8 +85,12 @@
 		<dict>
 			<key>Type</key>
 			<string>PSMultiValueSpecifier</string>
+			<key>FooterText</key>
+			<string>This setting determines whether successful 3DS verification is required in order to complete a transaction.
+
+The default option requires successful verification only if 3DS verification was attempted.</string>
 			<key>Title</key>
-			<string>Required (3DS Transaction Option)</string>
+			<string>Require for Transactions</string>
 			<key>Key</key>
 			<string>BraintreeDemoSettingsThreeDSecureRequiredDefaultsKey</string>
 			<key>Values</key>
@@ -99,9 +103,9 @@
 			<integer>0</integer>
 			<key>Titles</key>
 			<array>
-				<string>Default (Required if 3DS Verification present)</string>
+				<string>Default (Required if 3DS attempted)</string>
 				<string>Required</string>
-				<string>Optional (required = false)</string>
+				<string>Optional</string>
 			</array>
 			<key>ShortTitles</key>
 			<array>

--- a/DropInDemo/Merchant API Client/DemoMerchantAPIClient.swift
+++ b/DropInDemo/Merchant API Client/DemoMerchantAPIClient.swift
@@ -42,7 +42,7 @@ class DemoMerchantAPIClient: NSObject {
         
         if (DemoSettings.threeDSecureRequiredStatus == .required) {
             queryItems += [URLQueryItem(name: "three_d_secure_required", value: "true")]
-        } else if (DemoSettings.threeDSecureRequiredStatus == .notRequired) {
+        } else if (DemoSettings.threeDSecureRequiredStatus == .optional) {
             queryItems += [URLQueryItem(name: "three_d_secure_required", value: "false")]
         }
         

--- a/UITests/BraintreeDropIn_UITests.swift
+++ b/UITests/BraintreeDropIn_UITests.swift
@@ -943,7 +943,7 @@ class BraintreeDropIn_ThreeDSecure_2_UITests: XCTestCase {
 
         waitForElementToAppear(app.staticTexts["Purchase Authentication"], timeout: 20)
 
-        app.buttons["Cancel"].forceTapElement()
+        app.navigationBars["Secure Checkout"].buttons["Cancel"].forceTapElement()
         waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
         waitForElementToAppear(app.staticTexts["Select Payment Method"])
 


### PR DESCRIPTION
### Summary of changes

 - Update language and add a footer to clarify the purpose of a demo app setting that determines whether 3DS verification is required in order to process a transaction.
- Fix a UI test that was failing because multiple buttons with the text "Cancel" were found

 ### Checklist

 - [ ] ~Added a changelog entry~ 

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens
