### PR TITLE
Callback Handler: Disable User Interaction

### DIFF
--- a/BraintreeDropIn/BTDropInController.m
+++ b/BraintreeDropIn/BTDropInController.m
@@ -567,7 +567,7 @@
 
 #pragma mark Handler Callback
 
-// Show loading indicator and disable user interation to block additional actions.
+// Show loading indicator and disable user interaction to block additional actions.
 - (void)invokeHandlerWithResult:(BTDropInResult * __nullable)result error:(NSError * __nullable)error {
     if (self.handler) {
         dispatch_async(dispatch_get_main_queue(), ^{

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Disable user interaction and show loading indicator when `BTDropInControllerHandler` is invoked.
 * Require Braintree ~> 4.29
 * Add support for iOS 13 Dark Mode
   * Add `colorScheme` property to `BTUIKAppearance`, with support for light, dark and dynamic color schemes


### PR DESCRIPTION
### Summary of changes
Show loading indicator and disable user interaction when calling the final callback so that the user can not take additional actions.

Addresses one of the bullet points in https://github.com/braintree/braintree-ios-drop-in/issues/177

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- demerino
