### PR TITLE
Fix Incorrect `colorScheme` Docstring

### DIFF
--- a/BraintreeUIKit/Public/BTUIKAppearance.h
+++ b/BraintreeUIKit/Public/BTUIKAppearance.h
@@ -61,11 +61,11 @@ typedef NS_ENUM(NSInteger, BTUIKColorScheme) {
 @property (nonatomic, strong) UIColor *switchOnTintColor;
 /// Tint color for UISwitch thumb
 @property (nonatomic, strong) UIColor *switchThumbTintColor;
-/// Color scheme of the Drop-In UI. Only available in iOS 13+
+/// Color scheme of the Drop-In UI.
 ///
 /// When set to BTUIKColorSchemeLight, the Drop-In UI uses a light color palette.
 /// When set to BTUIKColorSchemeDark, the Drop-In UI uses a dark color palette.
-/// When set to BTUIKColorSchemeDynamic, the Drop-In UI uses a dark or light color palette depending on the user's light or dark mode system preference.
+/// When set to BTUIKColorSchemeDynamic, the Drop-In UI uses a dark or light color palette depending on the user's light or dark mode system preference. Only available in iOS 13+
 @property (nonatomic) enum BTUIKColorScheme colorScheme;
 /// Appearance style of keyboards associated with text fields
 @property (nonatomic) UIKeyboardAppearance keyboardAppearance;


### PR DESCRIPTION
### Summary of changes
 - Fix the docstring for `BTUIKAppearance.colorScheme` property. 
- Reflect that the property _is_ available on any iOS, but instead the `dynamicScheme` is only available on iOS 13. [`BTUIKColorScheme` definition](https://github.com/braintree/braintree-ios-drop-in/blob/f1376c9d681750cdf1d91b8e5ed5f827993dc4e5/BraintreeUIKit/Public/BTUIKAppearance.h#L5-L9 ).

### Authors
@scannillo 
