### PR TITLE
Change postal code default keyboard to alphanumeric

### DIFF
--- a/BraintreeUIKit/Helpers/BTUIKAppearance.m
+++ b/BraintreeUIKit/Helpers/BTUIKAppearance.m
@@ -86,7 +86,7 @@ static BTUIKAppearance *sharedTheme;
     sharedTheme.font = [UIFont systemFontOfSize:10];
     sharedTheme.boldFont = [UIFont boldSystemFontOfSize:10];
     sharedTheme.useBlurs = YES;
-    sharedTheme.postalCodeFormFieldKeyboardType = UIKeyboardTypeNumberPad;
+    sharedTheme.postalCodeFormFieldKeyboardType = UIKeyboardTypeDefault;
 }
 
 - (void)setDefaultColors {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Braintree iOS Drop-in SDK - Release Notes
 
+## unreleased
+* Change postal code default keyboard type to `UIKeyboardTypeDefault`
+
 ## 7.5.0 (2019-11-19)
 
 * Require Braintree ~> 4.30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Braintree iOS Drop-in SDK - Release Notes
 
 ## unreleased
-* Change postal code default keyboard type to `UIKeyboardTypeDefault`
+* Change postal code default keyboard type to `UIKeyboardTypeDefault` (NEXT_MAJOR_VERSION)
 
 ## 7.5.0 (2019-11-19)
 


### PR DESCRIPTION
### Summary of changes

- Our default keyboard type for postal code is currently only numeric.
- This PR changes our default keyboard type for postal code to be a standard keyboard (alphabetic & numeric). This is because our product is available internationally and some postal codes are alphanumeric.
- A merchant can still override this keyboard setting using `[BTUIKAppearance sharedInstance].postalCodeFormFieldKeyboardType`.
 - This PR is the result of the conversation in PR (https://github.com/braintree/braintree-ios-drop-in/pull/113).

 ### Checklist

 - [X] Added a changelog entry

### Authors
@scannillo 
