### PR TITLE
Pin to Base SDK with Cardinal UIWebView Fix

### DIFF
--- a/BraintreeDropIn.podspec
+++ b/BraintreeDropIn.podspec
@@ -27,11 +27,11 @@ Pod::Spec.new do |s|
     s.source_files  = "BraintreeDropIn/**/*.{h,m}"
     s.public_header_files = "BraintreeDropIn/Public/*.h"
     s.frameworks = "UIKit"
-    s.dependency "Braintree/Card", "~> 4.30"
-    s.dependency "Braintree/Core", "~> 4.30"
-    s.dependency "Braintree/UnionPay", "~> 4.30"
-    s.dependency "Braintree/PaymentFlow", "~> 4.30"
-    s.dependency "Braintree/PayPal", "~> 4.30"
+    s.dependency "Braintree/Card", ">= 4.30.2"
+    s.dependency "Braintree/Core", ">= 4.30.2"
+    s.dependency "Braintree/UnionPay", ">= 4.30.2"
+    s.dependency "Braintree/PaymentFlow", ">= 4.30.2"
+    s.dependency "Braintree/PayPal", ">= 4.30.2"
     s.dependency "BraintreeDropIn/UIKit"
   end
 

--- a/BraintreeDropIn.podspec
+++ b/BraintreeDropIn.podspec
@@ -27,11 +27,11 @@ Pod::Spec.new do |s|
     s.source_files  = "BraintreeDropIn/**/*.{h,m}"
     s.public_header_files = "BraintreeDropIn/Public/*.h"
     s.frameworks = "UIKit"
-    s.dependency "Braintree/Card", ">= 4.30.2"
-    s.dependency "Braintree/Core", ">= 4.30.2"
-    s.dependency "Braintree/UnionPay", ">= 4.30.2"
-    s.dependency "Braintree/PaymentFlow", ">= 4.30.2"
-    s.dependency "Braintree/PayPal", ">= 4.30.2"
+    s.dependency "Braintree/Card", "~> 4.31"
+    s.dependency "Braintree/Core", "~> 4.31"
+    s.dependency "Braintree/UnionPay", "~> 4.31"
+    s.dependency "Braintree/PaymentFlow", "~> 4.31"
+    s.dependency "Braintree/PayPal", "~> 4.31"
     s.dependency "BraintreeDropIn/UIKit"
   end
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Braintree iOS Drop-in SDK - Release Notes
 
+## unreleased
+* Update podspec to require versions `>= 4.30.2` of Braintree SDK
+
 ## 7.5.0 (2019-11-19)
 
 * Require Braintree ~> 4.30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Braintree iOS Drop-in SDK - Release Notes
 
 ## unreleased
-* Update podspec to require versions `>= 4.30.2` of Braintree SDK
+* Update podspec to require versions `~> 4.31` of Braintree SDK dependencies.
 
 ## 7.5.0 (2019-11-19)
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -28,11 +28,11 @@ PODS:
   - BraintreeDropIn (7.5.0):
     - BraintreeDropIn/DropIn (= 7.5.0)
   - BraintreeDropIn/DropIn (7.5.0):
-    - Braintree/Card (~> 4.30)
-    - Braintree/Core (~> 4.30)
-    - Braintree/PaymentFlow (~> 4.30)
-    - Braintree/PayPal (~> 4.30)
-    - Braintree/UnionPay (~> 4.30)
+    - Braintree/Card (>= 4.30.2)
+    - Braintree/Core (>= 4.30.2)
+    - Braintree/PaymentFlow (>= 4.30.2)
+    - Braintree/PayPal (>= 4.30.2)
+    - Braintree/UnionPay (>= 4.30.2)
     - BraintreeDropIn/UIKit
   - BraintreeDropIn/UIKit (7.5.0)
   - CardIO (5.4.1)
@@ -83,7 +83,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Braintree: 9fc21dc2ead57d104c4a0743454308e404217ec7
-  BraintreeDropIn: 15d6f53bf80bc0ae7809ab17803100c0a5448fd2
+  BraintreeDropIn: 2e28fa4514b8a2c5c0364f1988a94c7ac0b7acd9
   CardIO: 56983b39b62f495fc6dae9ad7cf875143df06443
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   InAppSettingsKit: 363ed5ea061ebcb76d69ca1eed08c8a4fe48baf2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,38 +1,38 @@
 PODS:
-  - Braintree/Apple-Pay (4.30.2):
+  - Braintree/Apple-Pay (4.31.0):
     - Braintree/Core
-  - Braintree/Card (4.30.2):
+  - Braintree/Card (4.31.0):
     - Braintree/Core
-  - Braintree/Core (4.30.2)
-  - Braintree/PaymentFlow (4.30.2):
+  - Braintree/Core (4.31.0)
+  - Braintree/PaymentFlow (4.31.0):
     - Braintree/Card
     - Braintree/Core
     - Braintree/PayPalOneTouch
-  - Braintree/PayPal (4.30.2):
+  - Braintree/PayPal (4.31.0):
     - Braintree/Core
     - Braintree/PayPalOneTouch
-  - Braintree/PayPalDataCollector (4.30.2):
+  - Braintree/PayPalDataCollector (4.31.0):
     - Braintree/Core
     - Braintree/PayPalUtils
-  - Braintree/PayPalOneTouch (4.30.2):
+  - Braintree/PayPalOneTouch (4.31.0):
     - Braintree/Core
     - Braintree/PayPalDataCollector
     - Braintree/PayPalUtils
-  - Braintree/PayPalUtils (4.30.2)
-  - Braintree/UnionPay (4.30.2):
+  - Braintree/PayPalUtils (4.31.0)
+  - Braintree/UnionPay (4.31.0):
     - Braintree/Card
     - Braintree/Core
-  - Braintree/Venmo (4.30.2):
+  - Braintree/Venmo (4.31.0):
     - Braintree/Core
     - Braintree/PayPalDataCollector
   - BraintreeDropIn (7.5.0):
     - BraintreeDropIn/DropIn (= 7.5.0)
   - BraintreeDropIn/DropIn (7.5.0):
-    - Braintree/Card (>= 4.30.2)
-    - Braintree/Core (>= 4.30.2)
-    - Braintree/PaymentFlow (>= 4.30.2)
-    - Braintree/PayPal (>= 4.30.2)
-    - Braintree/UnionPay (>= 4.30.2)
+    - Braintree/Card (~> 4.31)
+    - Braintree/Core (~> 4.31)
+    - Braintree/PaymentFlow (~> 4.31)
+    - Braintree/PayPal (~> 4.31)
+    - Braintree/UnionPay (~> 4.31)
     - BraintreeDropIn/UIKit
   - BraintreeDropIn/UIKit (7.5.0)
   - CardIO (5.4.1)
@@ -82,8 +82,8 @@ EXTERNAL SOURCES:
     :path: "./"
 
 SPEC CHECKSUMS:
-  Braintree: 9fc21dc2ead57d104c4a0743454308e404217ec7
-  BraintreeDropIn: 2e28fa4514b8a2c5c0364f1988a94c7ac0b7acd9
+  Braintree: c20fb599a8cfee54ad7dfc603dee68f0922bfcba
+  BraintreeDropIn: 24ee6c3e79b51defd5eea91dcc7751b5b56da0be
   CardIO: 56983b39b62f495fc6dae9ad7cf875143df06443
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   InAppSettingsKit: 363ed5ea061ebcb76d69ca1eed08c8a4fe48baf2


### PR DESCRIPTION
### Summary of changes 

- The `UIWebView` [warning/alert issue ](https://github.com/braintree/braintree-ios-drop-in/issues/193)was caused by the Cardinal SDK. This issue was resolved in version 4.30.2 of `braintree_ios`. 
- This PR specifies Drop-In to require `~> 4.31` of Braintree SDK. 
- This [syntax](https://guides.cocoapods.org/using/the-podfile.html#specifying-pod-versions)  specifies v4.31 and the versions up to 5.0 not including 5.0 and higher. This allows us to require the fix for `UIWebView` and prevent breaking changes from the next major version.

 ### Checklist

 - [X] Added a changelog entry

### Authors
- @scannillo 
- @sestevens 
