### PR TITLE
Support passing the vault option to the venmo tokenization service

### DIFF
--- a/BraintreeDropIn/BTPaymentSelectionViewController.m
+++ b/BraintreeDropIn/BTPaymentSelectionViewController.m
@@ -491,6 +491,7 @@ static BOOL _vaultedCardAppearAnalyticSent = NO;
         }
     } else if (cell.type == BTUIKPaymentOptionTypeVenmo) {
         NSMutableDictionary *options = [NSMutableDictionary dictionary];
+        options[@"vault"] = [NSNumber numberWithBool:self.dropInRequest.vaultVenmo];
         if (self.delegate != nil) {
             options[BTTokenizationServiceViewPresentingDelegateOption] = self.delegate;
         }

--- a/BraintreeDropIn/Models/BTDropInRequest.m
+++ b/BraintreeDropIn/Models/BTDropInRequest.m
@@ -11,6 +11,7 @@
     self = [super init];
     if (self) {
         _vaultCard = YES;
+        _vaultVenmo = YES;
     }
 
     return self;
@@ -35,6 +36,7 @@
     request.vaultManager = self.vaultManager;
     request.vaultCard = self.vaultCard;
     request.allowVaultCardOverride = self.allowVaultCardOverride;
+    request.vaultVenmo = self.vaultVenmo;
     return request;
 }
 

--- a/BraintreeDropIn/Public/BTDropInRequest.h
+++ b/BraintreeDropIn/Public/BTDropInRequest.h
@@ -71,6 +71,10 @@ typedef NS_ENUM(NSInteger, BTFormFieldSetting) {
 /// Defaults to false
 @property (nonatomic, assign) BOOL allowVaultCardOverride;
 
+/// Optional: Whether or not to vault the venmo upon tokenization, must be set to false when using a client token without a customer.
+/// Defaults to true
+@property (nonatomic, assign) BOOL vaultVenmo;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/BraintreeDropIn/Public/BTDropInRequest.h
+++ b/BraintreeDropIn/Public/BTDropInRequest.h
@@ -71,7 +71,7 @@ typedef NS_ENUM(NSInteger, BTFormFieldSetting) {
 /// Defaults to false
 @property (nonatomic, assign) BOOL allowVaultCardOverride;
 
-/// Optional: Whether or not to vault the venmo upon tokenization, must be set to false when using a client token without a customer.
+/// Optional: Whether or not to vault the Venmo payment method upon tokenization, must be set to `false` when using a client token without a `customerId`.
 /// Defaults to true
 @property (nonatomic, assign) BOOL vaultVenmo;
 

--- a/UnitTests/BTDropInRequestTests.m
+++ b/UnitTests/BTDropInRequestTests.m
@@ -55,6 +55,7 @@
     originalRequest.vaultManager = YES;
     originalRequest.vaultCard = NO;
     originalRequest.allowVaultCardOverride = YES;
+    originalRequest.vaultVenmo = NO;
 
     BTDropInRequest *copiedRequest = [originalRequest copy];
 
@@ -74,6 +75,7 @@
     XCTAssertEqual(originalRequest.vaultManager, copiedRequest.vaultManager);
     XCTAssertEqual(originalRequest.vaultCard, copiedRequest.vaultCard);
     XCTAssertEqual(originalRequest.allowVaultCardOverride, copiedRequest.allowVaultCardOverride);
+    XCTAssertEqual(originalRequest.vaultVenmo, copiedRequest.vaultVenmo);
 
     XCTAssertEqual(originalRequest.threeDSecureRequest, copiedRequest.threeDSecureRequest);
     XCTAssertEqual(BTThreeDSecureVersion2, copiedRequest.threeDSecureRequest.versionRequested);


### PR DESCRIPTION
### Summary of changes

- Adds the vaultVenmo option and passes the `vault` key to the tokenization service.
- Requires an update to BraintreeVenmo to support the new key

 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

Co-authored-by: demerino <david.eros.merino@gmail.com>
