### PR TITLE
Require core ~4.32

### DIFF
--- a/BraintreeDropIn.podspec
+++ b/BraintreeDropIn.podspec
@@ -27,11 +27,11 @@ Pod::Spec.new do |s|
     s.source_files  = "BraintreeDropIn/**/*.{h,m}"
     s.public_header_files = "BraintreeDropIn/Public/*.h"
     s.frameworks = "UIKit"
-    s.dependency "Braintree/Card", "~> 4.31"
-    s.dependency "Braintree/Core", "~> 4.31"
-    s.dependency "Braintree/UnionPay", "~> 4.31"
-    s.dependency "Braintree/PaymentFlow", "~> 4.31"
-    s.dependency "Braintree/PayPal", "~> 4.31"
+    s.dependency "Braintree/Card", "~> 4.32"
+    s.dependency "Braintree/Core", "~> 4.32"
+    s.dependency "Braintree/UnionPay", "~> 4.32"
+    s.dependency "Braintree/PaymentFlow", "~> 4.32"
+    s.dependency "Braintree/PayPal", "~> 4.32"
     s.dependency "BraintreeDropIn/UIKit"
   end
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS Drop-in SDK - Release Notes
 
+## Unreleased
+
+* Require Braintree ~> 4.32
+
 ## 8.0.0 (2020-02-06)
 
 * Remove deprecated methods and properties


### PR DESCRIPTION
### Summary of changes

 - Require core 4.32 in order to get support for Venmo Vaulting option 

 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- david.merino@getbraintree.com
