### PR TITLE
Show activity indicator on payment selection screen

### DIFF
--- a/BraintreeDropIn/BTDropInController.m
+++ b/BraintreeDropIn/BTDropInController.m
@@ -290,6 +290,7 @@
         request.threeDSecureRequestDelegate = self;
     }
 
+    [self.paymentSelectionViewController showLoadingScreen: YES];
     [paymentFlowDriver startPaymentFlow:request completion:^(BTPaymentFlowResult * _Nonnull result, NSError * _Nonnull error) {
         BTThreeDSecureResult *threeDSecureResult = (BTThreeDSecureResult *)result;
         [self.paymentSelectionViewController showLoadingScreen:NO];

--- a/BraintreeDropIn/BTPaymentSelectionViewController.m
+++ b/BraintreeDropIn/BTPaymentSelectionViewController.m
@@ -477,13 +477,17 @@ static BOOL _vaultedCardAppearAnalyticSent = NO;
 
         // One time payment if an amount is present
         if (payPalRequest.amount) {
+            [self showLoadingScreen:YES];
             [driver requestOneTimePayment:payPalRequest completion:^(BTPayPalAccountNonce * _Nullable payPalAccount, NSError * _Nullable error) {
+                [self showLoadingScreen:NO];
                 if (self.delegate && (payPalAccount != nil || error != nil)) {
                     [self.delegate selectionCompletedWithPaymentMethodType:BTUIKPaymentOptionTypePayPal nonce:payPalAccount error:error];
                 }
             }];
         } else {
+            [self showLoadingScreen:YES];
             [driver requestBillingAgreement:payPalRequest completion:^(BTPayPalAccountNonce * _Nullable payPalAccount, NSError * _Nullable error) {
+                [self showLoadingScreen:NO];
                 if (self.delegate && (payPalAccount != nil || error != nil)) {
                     [self.delegate selectionCompletedWithPaymentMethodType:BTUIKPaymentOptionTypePayPal nonce:payPalAccount error:error];
                 }
@@ -495,7 +499,9 @@ static BOOL _vaultedCardAppearAnalyticSent = NO;
         if (self.delegate != nil) {
             options[BTTokenizationServiceViewPresentingDelegateOption] = self.delegate;
         }
+        [self showLoadingScreen:YES];
         [[BTTokenizationService sharedService] tokenizeType:@"Venmo" options:options withAPIClient:self.apiClient completion:^(BTPaymentMethodNonce * _Nullable paymentMethodNonce, NSError * _Nullable error) {
+            [self showLoadingScreen:NO];
             if (self.delegate && (paymentMethodNonce != nil || error != nil)) {
                 [self.delegate selectionCompletedWithPaymentMethodType:BTUIKPaymentOptionTypeVenmo nonce:paymentMethodNonce error:error];
             }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS Drop-in SDK - Release Notes
 
+## unreleased
+
+* Show activity indicator on payment method selection screen at the beginning of PayPal, Venmo and 3DS flows
+
 ## 8.1.0 (2020-04-01)
 
 * Add `vaultVenmo` flag to `BTDropInRequest`


### PR DESCRIPTION
### Summary of changes

- Show activity indicator on payment method selection screen at the beginning of PayPal, Venmo and 3DS flows. This addresses #177.
- Update CocoaPods

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens 
