### PR TITLE
Update Constraints for SwiftUI Support

### DIFF
--- a/BraintreeDropIn/BTDropInController.m
+++ b/BraintreeDropIn/BTDropInController.m
@@ -93,12 +93,16 @@
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
 
-    if (self.isBeingPresented) {
-        [self.paymentSelectionViewController loadConfiguration];
-        [self resetDropInState];
-        [self loadConfiguration];
-    }
+    [self.paymentSelectionViewController loadConfiguration];
+    [self resetDropInState];
+    [self loadConfiguration];
     [self.apiClient sendAnalyticsEvent:@"ios.dropin2.appear"];
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    self.contentViewTopConstraint.constant = [self calculateContentViewTopConstraintConstant];
+    self.contentViewBottomConstraint.constant = -[self sheetInset];
 }
 
 - (void)viewWillDisappear:(BOOL)animated {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## unreleased
 
-* Show activity indicator on payment method selection screen at the beginning of PayPal, Venmo and 3DS flows
+* Show activity indicator on payment method selection screen at the beginning of PayPal, Venmo and 3DS flows (resolves #177)
+* Update constraints for SwiftUI support (resolves #202)
 
 ## 8.1.0 (2020-04-01)
 


### PR DESCRIPTION


### Summary of changes

 - Update constraints for SwiftUI support. The `safeAreaLayoutGuide` does not take into account navigation and tool bars until `viewDidAppear`. See [Apple docs](https://developer.apple.com/documentation/uikit/uiview/2891102-safearealayoutguide).
- We also removed a check for `isBeingPresented`, which was not returning true in our SwiftUI demo. It looks like it's unnecessary (according to [these docs](https://docs.microsoft.com/pl-pl/dotnet/api/uikit.uiviewcontroller.isbeingpresented?view=xamarin-ios-sdk-12)).
- This resolves #202.

NOTE: To test this change on a SwiftUI demo app, checkout the [swiftui-demo branch](https://github.com/braintree/braintree-ios-drop-in/tree/swiftui-demo).

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens 
- @scannillo 
