### PR TITLE
Fix Braintree module imports

### DIFF
--- a/BraintreeDropIn/BTAPIClient_Internal_Category.h
+++ b/BraintreeDropIn/BTAPIClient_Internal_Category.h
@@ -1,7 +1,7 @@
 #if __has_include("BraintreeCore.h")
 #import "BraintreeCore.h"
 #else
-#import <BraintreeCore/BraintreeCore.h>
+#import <Braintree/BraintreeCore.h>
 #endif
 
 NS_ASSUME_NONNULL_BEGIN

--- a/BraintreeDropIn/BTCardFormViewController.m
+++ b/BraintreeDropIn/BTCardFormViewController.m
@@ -5,7 +5,7 @@
 #if __has_include("BraintreeCore.h")
 #import "BraintreeCore.h"
 #else
-#import <BraintreeCore/BraintreeCore.h>
+#import <Braintree/BraintreeCore.h>
 #endif
 #import "BTAPIClient_Internal_Category.h"
 #import "BTUIKBarButtonItem_Internal_Declaration.h"
@@ -14,17 +14,17 @@
 #if __has_include("BraintreeCard.h")
 #import "BraintreeCard.h"
 #else
-#import <BraintreeCard/BraintreeCard.h>
+#import <Braintree/BraintreeCard.h>
 #endif
 #if __has_include("BraintreeUnionPay.h")
 #import "BraintreeUnionPay.h"
 #else
-#import <BraintreeUnionPay/BraintreeUnionPay.h>
+#import <Braintree/BraintreeUnionPay.h>
 #endif
 #if __has_include("BraintreePaymentFlow.h")
 #import "BraintreePaymentFlow.h"
 #else
-#import <BraintreePaymentFlow/BraintreePaymentFlow.h>
+#import <Braintree/BraintreePaymentFlow.h>
 #endif
 
 @interface BTCardFormViewController ()

--- a/BraintreeDropIn/BTDropInController.m
+++ b/BraintreeDropIn/BTDropInController.m
@@ -6,19 +6,19 @@
 #if __has_include("BraintreeCore.h")
 #import "BraintreeCore.h"
 #else
-#import <BraintreeCore/BraintreeCore.h>
+#import <Braintree/BraintreeCore.h>
 #endif
 #if __has_include("BraintreeCard.h")
 #import "BraintreeCard.h"
 #import "BraintreeUnionPay.h"
 #else
-#import <BraintreeCard/BraintreeCard.h>
-#import <BraintreeUnionPay/BraintreeUnionPay.h>
+#import <Braintree/BraintreeCard.h>
+#import <Braintree/BraintreeUnionPay.h>
 #endif
 #if __has_include("BraintreePaymentFlow.h")
 #import "BraintreePaymentFlow.h"
 #else
-#import <BraintreePaymentFlow/BraintreePaymentFlow.h>
+#import <Braintree/BraintreePaymentFlow.h>
 #endif
 
 #define BT_ANIMATION_SLIDE_SPEED 0.35

--- a/BraintreeDropIn/BTPaymentSelectionViewController.m
+++ b/BraintreeDropIn/BTPaymentSelectionViewController.m
@@ -15,13 +15,13 @@
 #if __has_include("BraintreeCard.h")
 #import "BraintreeCard.h"
 #else
-#import <BraintreeCard/BraintreeCard.h>
+#import <Braintree/BraintreeCard.h>
 #endif
 
 #if __has_include("BraintreePayPal.h")
 #import "BraintreePayPal.h"
 #else
-#import <BraintreePayPal/BraintreePayPal.h>
+#import <Braintree/BraintreePayPal.h>
 #endif
 
 #if __has_include("BraintreeApplePay.h")

--- a/BraintreeDropIn/BTVaultManagementViewController.m
+++ b/BraintreeDropIn/BTVaultManagementViewController.m
@@ -5,12 +5,12 @@
 #if __has_include("BraintreeCore.h")
 #import "BraintreeCore.h"
 #else
-#import <BraintreeCore/BraintreeCore.h>
+#import <Braintree/BraintreeCore.h>
 #endif
 #if __has_include("BraintreeCard.h")
 #import "BraintreeCard.h"
 #else
-#import <BraintreeCard/BraintreeCard.h>
+#import <Braintree/BraintreeCard.h>
 #endif
 
 @interface BTVaultManagementViewController ()

--- a/BraintreeDropIn/Custom Views/BTUIPaymentMethodCollectionViewCell.h
+++ b/BraintreeDropIn/Custom Views/BTUIPaymentMethodCollectionViewCell.h
@@ -3,7 +3,7 @@
 #if __has_include("BTPaymentMethodNonce.h")
 #import "BTPaymentMethodNonce.h"
 #else
-#import <BraintreeCore/BTPaymentMethodNonce.h>
+#import <Braintree/BTPaymentMethodNonce.h>
 #endif
 
 @class BTUIKPaymentOptionCardView;

--- a/BraintreeDropIn/Models/BTDropInRequest.m
+++ b/BraintreeDropIn/Models/BTDropInRequest.m
@@ -1,8 +1,8 @@
 #import "BTDropInRequest.h"
 #if __has_include("BraintreeCore.h")
-#import "BTPostalAddress.h"
+#import "BraintreeCore.h"
 #else
-#import <BraintreeCore/BTPostalAddress.h>
+#import <Braintree/BraintreeCore.h>
 #endif
 
 @implementation BTDropInRequest

--- a/BraintreeDropIn/Models/BTDropInResult.m
+++ b/BraintreeDropIn/Models/BTDropInResult.m
@@ -3,7 +3,7 @@
 #if __has_include("BraintreeCore.h")
 #import "BraintreeCore.h"
 #else
-#import <BraintreeCore/BraintreeCore.h>
+#import <Braintree/BraintreeCore.h>
 #endif
 #if __has_include("BraintreeUIKit.h")
 #import "BraintreeUIKit.h"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS Drop-in SDK - Release Notes
 
+## unreleased
+
+* Fix Braintree module imports
+
 ## 8.1.1 (2020-07-14)
 
 * Show activity indicator on payment method selection screen at the beginning of PayPal, Venmo and 3DS flows (resolves #177)


### PR DESCRIPTION
Hi,

Thank you very much for great library!

I am integrating `BraintreeDropIn` using cocoapods and I started to face an issue when specific installation option is used.

Starting with [1.7.0](https://blog.cocoapods.org/CocoaPods-1.7.0-beta/) cocoapods allow to specify `generate_multiple_pod_projects` option in `Podfile`. When used, it helps to improve performance and reduce compile time.

Unfortunately `BraintreeDropIn` fails to compile with this option in `Podfile` because cocoapods generates separate project per dependency which results in separate modules. Eventually compilation fails because `Braintree` module imports are not correct. Please see attached logs: [Build BraintreeDropIn_2020-10-04T20-34-19.txt](https://github.com/braintree/braintree-ios-drop-in/files/5324435/Build.BraintreeDropIn_2020-10-04T20-34-19.txt)

I would be grateful for your feedback.

Thanks!

### Summary of changes

 - Fix `Braintree` module imports
 - Update changelog

 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @demalex
