### PR TITLE
Fix Travis CI Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: objective-c
-osx_image: xcode11.3
+osx_image: xcode12
 
 cache:
   bundler: true
   cocoapods: true
 
 script:
-  - set -o pipefail && xcodebuild -workspace BraintreeDropIn.xcworkspace -scheme DropInDemo -destination platform\=iOS\ Simulator,OS\=13.3,name\=iPhone\ 11 build test | bundle exec xcpretty -c
+  - set -o pipefail && xcodebuild -workspace BraintreeDropIn.xcworkspace -scheme DropInDemo -destination platform\=iOS\ Simulator,OS\=14.0,name\=iPhone\ 11 build test | ./Pods/xcbeautify/xcbeautify
 

--- a/BraintreeDropIn.xcodeproj/xcshareddata/xcschemes/DropInDemo.xcscheme
+++ b/BraintreeDropIn.xcodeproj/xcshareddata/xcschemes/DropInDemo.xcscheme
@@ -48,8 +48,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "A5411A291D8A20D00041BE92"

--- a/BraintreeDropIn.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
+++ b/BraintreeDropIn.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
@@ -13,8 +13,7 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "A5411A291D8A20D00041BE92"

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,4 @@ gem 'rake'
 gem 'git-pairing'
 gem 'highline', :require => 'highline/import'
 gem 'rake_commit'
-gem 'xcpretty'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,6 @@ GEM
     paint (2.2.0)
     rake (13.0.1)
     rake_commit (1.2.0)
-    rouge (2.0.7)
     ruby-macho (1.4.0)
     thread_safe (0.3.6)
     trollop (2.9.10)
@@ -85,14 +84,12 @@ GEM
       ethon (>= 0.9.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
-    xcodeproj (1.18.0)
+    xcodeproj (1.19.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
-    xcpretty (0.3.0)
-      rouge (~> 2.0.7)
 
 PLATFORMS
   ruby
@@ -103,7 +100,6 @@ DEPENDENCIES
   highline
   rake
   rake_commit
-  xcpretty
 
 BUNDLED WITH
    2.1.4

--- a/Rakefile
+++ b/Rakefile
@@ -82,9 +82,7 @@ namespace :spec do
 
   desc 'Run UI tests'
   task :ui do
-    ENV['NSUnbufferedIO'] = 'YES' #Forces parallel test output to be printed after each test rather than on completion of all tests
-    run_test_scheme! 'UITests', nil, '2>&1'
-    ENV['NSUnbufferedIO'] = 'NO'
+    run_test_scheme! 'UITests'
   end
 
   desc 'Run all spec schemes'


### PR DESCRIPTION
### What
- Get CI to run unit and UI tests again

### How
- Remove `xcpretty` entirely 
- Use `xcbeautify` in the travis file instead
- Bump travis settings to xcode 12 and ios 14
- Removed ability for UI tests to run in parallel. 
    - UI tests [were made to run in parallel in this PR](https://github.com/braintree/braintree-ios-drop-in/pull/229). I notice it's making the CI running for the UI tests flakey. While setting up the 3 simulators, I am seeing the CI just hang and then timeout before being able to run the UI tests at all.