### PR TITLE
Updates for CI Stability

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,12 +8,12 @@ jobs:
       # Checks out a copy of your repository
       - name: Checkout repository
         uses: actions/checkout@v1
+      - name: Use Xcode 12.2
+        run: sudo xcode-select -switch /Applications/Xcode_12.2.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run Unit Tests
         run: set -o pipefail && xcodebuild -workspace 'BraintreeDropIn.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'UnitTests' -destination 'name=iPhone 11,platform=iOS Simulator'  test  | ./Pods/xcbeautify/xcbeautify
-        env:
-          DEVELOPER_DIR: /Applications/Xcode_12.app/Contents/Developer
   ui_test_job:
     name: UI Tests
     runs-on: macOS-latest
@@ -21,9 +21,9 @@ jobs:
       # Checks out a copy of your repository
       - name: Checkout repository
         uses: actions/checkout@v1
+      - name: Use Xcode 12.2
+        run: sudo xcode-select -switch /Applications/Xcode_12.2.app
       - name: Install CocoaPod dependencies
         run: pod install
       - name: Run UI Tests
         run: set -o pipefail && xcodebuild -workspace 'BraintreeDropIn.xcworkspace' -sdk 'iphonesimulator' -configuration 'Release' -scheme 'UITests' -destination 'name=iPhone 11,platform=iOS Simulator'  test  | ./Pods/xcbeautify/xcbeautify
-        env:
-          DEVELOPER_DIR: /Applications/Xcode_12.app/Contents/Developer

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,40 +1,40 @@
 PODS:
-  - Braintree/Apple-Pay (4.34.0):
+  - Braintree/Apple-Pay (4.36.1):
     - Braintree/Core
-  - Braintree/Card (4.34.0):
+  - Braintree/Card (4.36.1):
     - Braintree/Core
-  - Braintree/Core (4.34.0)
-  - Braintree/PaymentFlow (4.34.0):
+  - Braintree/Core (4.36.1)
+  - Braintree/PaymentFlow (4.36.1):
     - Braintree/Card
     - Braintree/Core
     - Braintree/PayPalOneTouch
-  - Braintree/PayPal (4.34.0):
+  - Braintree/PayPal (4.36.1):
     - Braintree/Core
     - Braintree/PayPalOneTouch
-  - Braintree/PayPalDataCollector (4.34.0):
+  - Braintree/PayPalDataCollector (4.36.1):
     - Braintree/Core
     - Braintree/PayPalUtils
-  - Braintree/PayPalOneTouch (4.34.0):
+  - Braintree/PayPalOneTouch (4.36.1):
     - Braintree/Core
     - Braintree/PayPalDataCollector
     - Braintree/PayPalUtils
-  - Braintree/PayPalUtils (4.34.0)
-  - Braintree/UnionPay (4.34.0):
+  - Braintree/PayPalUtils (4.36.1)
+  - Braintree/UnionPay (4.36.1):
     - Braintree/Card
     - Braintree/Core
-  - Braintree/Venmo (4.34.0):
+  - Braintree/Venmo (4.36.1):
     - Braintree/Core
     - Braintree/PayPalDataCollector
-  - BraintreeDropIn (8.1.1):
-    - BraintreeDropIn/DropIn (= 8.1.1)
-  - BraintreeDropIn/DropIn (8.1.1):
+  - BraintreeDropIn (8.1.2):
+    - BraintreeDropIn/DropIn (= 8.1.2)
+  - BraintreeDropIn/DropIn (8.1.2):
     - Braintree/Card (~> 4.32)
     - Braintree/Core (~> 4.32)
     - Braintree/PaymentFlow (~> 4.32)
     - Braintree/PayPal (~> 4.32)
     - Braintree/UnionPay (~> 4.32)
     - BraintreeDropIn/UIKit
-  - BraintreeDropIn/UIKit (8.1.1)
+  - BraintreeDropIn/UIKit (8.1.2)
   - Expecta (1.0.6)
   - InAppSettingsKit (3.1.2)
   - OCMock (3.6)
@@ -82,8 +82,8 @@ EXTERNAL SOURCES:
     :path: "./"
 
 SPEC CHECKSUMS:
-  Braintree: 48154e70306eb3e6c81eaa87bbc5c5988c0d2784
-  BraintreeDropIn: c91c95b725eb4169956a755a1b1803b10f2df4c2
+  Braintree: f7e0e9a5030e22b8ad77e617f27ac9327d7bc004
+  BraintreeDropIn: 50b79151c55f2ffbfbbf9157c2d07d8e85479588
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   InAppSettingsKit: 988142fed825524ae44dd0d93684daf8f0358b8c
   OCMock: 5ea90566be239f179ba766fd9fbae5885040b992
@@ -93,4 +93,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 3d954c4b165c75add886b9c6b53e412afc04e4ba
 
-COCOAPODS: 1.9.3
+COCOAPODS: 1.10.0

--- a/UITests/BraintreeDropIn_UITests.swift
+++ b/UITests/BraintreeDropIn_UITests.swift
@@ -565,7 +565,7 @@ class BraintreeDropIn_PayPal_UITests: XCTestCase {
         
         let webviewElementsQuery = app.webViews.element.otherElements
         
-        waitForElementToBeHittable(webviewElementsQuery.links["Proceed with Sandbox Purchase"])
+        waitForElementToBeHittable(webviewElementsQuery.links["Proceed with Sandbox Purchase"], timeout: 20)
         
         webviewElementsQuery.links["Proceed with Sandbox Purchase"].forceTapElement()
         
@@ -585,7 +585,7 @@ class BraintreeDropIn_PayPal_UITests: XCTestCase {
 
         let webviewElementsQuery = app.webViews.element.otherElements
 
-        waitForElementToBeHittable(webviewElementsQuery.links["Cancel Sandbox Purchase"])
+        waitForElementToBeHittable(webviewElementsQuery.links["Cancel Sandbox Purchase"], timeout: 20)
 
         webviewElementsQuery.links["Cancel Sandbox Purchase"].forceTapElement()
 
@@ -626,7 +626,7 @@ class BraintreeDropIn_PayPal_OneTime_UITests: XCTestCase {
 
         waitForElementToAppear(webviewElementsQuery.staticTexts["4.77"])
 
-        waitForElementToBeHittable(webviewElementsQuery.links["Proceed with Sandbox Purchase"])
+        waitForElementToBeHittable(webviewElementsQuery.links["Proceed with Sandbox Purchase"], timeout: 20)
 
         webviewElementsQuery.links["Proceed with Sandbox Purchase"].forceTapElement()
 


### PR DESCRIPTION


### Summary of changes

* Update GH Actions file so that we always use Xcode 12.2. UI tests were sometimes running into an error where GH Actions couldn't find the correct simulator, and this change to our `testing.yml` file seems to resolve that issue. See this [SO post](https://stackoverflow.com/a/59508420).

* Increase timeout on PayPal tests. These tests fail sporadically in CI, so maybe increasing the timeout will help?

* Bump Braintree pod to 4.36.1

 ### Checklist

 - ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens 
