### PR TITLE
Use Braintree 5.0.0-beta1

### DIFF
--- a/BraintreeDropIn.podspec
+++ b/BraintreeDropIn.podspec
@@ -27,11 +27,11 @@ Pod::Spec.new do |s|
     s.source_files  = "Sources/BraintreeDropIn/**/*.{h,m}"
     s.public_header_files = "Sources/BraintreeDropIn/Public/BraintreeDropIn/*.h"
     s.frameworks = "UIKit"
-    s.dependency "Braintree/Card", "~> 5.0.0-beta1"
-    s.dependency "Braintree/Core", "~> 5.0.0-beta1"
-    s.dependency "Braintree/UnionPay", "~> 5.0.0-beta1"
-    s.dependency "Braintree/PaymentFlow", "~> 5.0.0-beta1"
-    s.dependency "Braintree/PayPal", "~> 5.0.0-beta1"
+    s.dependency "Braintree/Card", "~> 5.0.0-beta"
+    s.dependency "Braintree/Core", "~> 5.0.0-beta"
+    s.dependency "Braintree/UnionPay", "~> 5.0.0-beta"
+    s.dependency "Braintree/PaymentFlow", "~> 5.0.0-beta"
+    s.dependency "Braintree/PayPal", "~> 5.0.0-beta"
     s.dependency "BraintreeDropIn/UIKit"
   end
 

--- a/BraintreeDropIn.podspec
+++ b/BraintreeDropIn.podspec
@@ -27,11 +27,11 @@ Pod::Spec.new do |s|
     s.source_files  = "Sources/BraintreeDropIn/**/*.{h,m}"
     s.public_header_files = "Sources/BraintreeDropIn/Public/BraintreeDropIn/*.h"
     s.frameworks = "UIKit"
-    s.dependency "Braintree/Card", "~> 4.32"
-    s.dependency "Braintree/Core", "~> 4.32"
-    s.dependency "Braintree/UnionPay", "~> 4.32"
-    s.dependency "Braintree/PaymentFlow", "~> 4.32"
-    s.dependency "Braintree/PayPal", "~> 4.32"
+    s.dependency "Braintree/Card", "~> 5.0.0-beta1"
+    s.dependency "Braintree/Core", "~> 5.0.0-beta1"
+    s.dependency "Braintree/UnionPay", "~> 5.0.0-beta1"
+    s.dependency "Braintree/PaymentFlow", "~> 5.0.0-beta1"
+    s.dependency "Braintree/PayPal", "~> 5.0.0-beta1"
     s.dependency "BraintreeDropIn/UIKit"
   end
 

--- a/BraintreeDropIn.xcodeproj/project.pbxproj
+++ b/BraintreeDropIn.xcodeproj/project.pbxproj
@@ -13,6 +13,9 @@
 		03AE59581DDE7E8C000B594C /* BTUIKVisualAssetType.h in Headers */ = {isa = PBXBuildFile; fileRef = 03AE59571DDE7E8C000B594C /* BTUIKVisualAssetType.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		03B793AD1DAD61B500F54B1B /* BTDropInResultTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 03B793AC1DAD61B500F54B1B /* BTDropInResultTests.m */; };
 		2F7FB0ECFD9A424F15670E5A /* Pods_All_BraintreeDropIn.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B93F29A91004AF33552E0830 /* Pods_All_BraintreeDropIn.framework */; };
+		4225EA53257EC1EB00923CE3 /* BTPaymentMethodNonce+DropIn.h in Headers */ = {isa = PBXBuildFile; fileRef = 4225EA52257EC1EB00923CE3 /* BTPaymentMethodNonce+DropIn.h */; };
+		4225EA58257EC36300923CE3 /* BTPaymentMethodNonce+DropIn.m in Sources */ = {isa = PBXBuildFile; fileRef = 4225EA57257EC36300923CE3 /* BTPaymentMethodNonce+DropIn.m */; };
+		4225EA87257EC59600923CE3 /* BTPaymentMethodNonce+DropInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4225EA86257EC59600923CE3 /* BTPaymentMethodNonce+DropInTests.swift */; };
 		4245DAF3256C721D00F1A413 /* FakeApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4245DAF2256C721D00F1A413 /* FakeApplication.swift */; };
 		425B83982347D3990015D1A4 /* BTUIKAppearanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 425B83972347D3990015D1A4 /* BTUIKAppearanceTests.swift */; };
 		42ACD3A025798A03000BE57C /* BraintreeDropIn.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A56C416A1D833348000DFFAB /* BraintreeDropIn.framework */; };
@@ -220,6 +223,9 @@
 		0BD902D41FE8E71BAC1F2CDF /* Pods-All-BraintreeDropIn.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-All-BraintreeDropIn.release.xcconfig"; path = "Target Support Files/Pods-All-BraintreeDropIn/Pods-All-BraintreeDropIn.release.xcconfig"; sourceTree = "<group>"; };
 		2C49A2D3017C36DE7AF6C8EF /* Pods-All-BraintreeDropIn.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-All-BraintreeDropIn.debug.xcconfig"; path = "Target Support Files/Pods-All-BraintreeDropIn/Pods-All-BraintreeDropIn.debug.xcconfig"; sourceTree = "<group>"; };
 		3622655EA20BF44ED95826D3 /* Pods-BraintreeDropIn.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BraintreeDropIn.debug.xcconfig"; path = "Target Support Files/Pods-BraintreeDropIn/Pods-BraintreeDropIn.debug.xcconfig"; sourceTree = "<group>"; };
+		4225EA52257EC1EB00923CE3 /* BTPaymentMethodNonce+DropIn.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BTPaymentMethodNonce+DropIn.h"; sourceTree = "<group>"; };
+		4225EA57257EC36300923CE3 /* BTPaymentMethodNonce+DropIn.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "BTPaymentMethodNonce+DropIn.m"; sourceTree = "<group>"; };
+		4225EA86257EC59600923CE3 /* BTPaymentMethodNonce+DropInTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BTPaymentMethodNonce+DropInTests.swift"; sourceTree = "<group>"; };
 		4245DAF2256C721D00F1A413 /* FakeApplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeApplication.swift; sourceTree = "<group>"; };
 		425B83972347D3990015D1A4 /* BTUIKAppearanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BTUIKAppearanceTests.swift; sourceTree = "<group>"; };
 		42A10AD8230EE4D600892302 /* UnitTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UnitTests-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -720,6 +726,7 @@
 				425B83972347D3990015D1A4 /* BTUIKAppearanceTests.swift */,
 				42A10AD8230EE4D600892302 /* UnitTests-Bridging-Header.h */,
 				4245DAF2256C721D00F1A413 /* FakeApplication.swift */,
+				4225EA86257EC59600923CE3 /* BTPaymentMethodNonce+DropInTests.swift */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
@@ -755,6 +762,7 @@
 				A56C41891D833568000DFFAB /* BTDropInController.m */,
 				A56C418A1D833568000DFFAB /* BTDropInUIUtilities.h */,
 				A56C418B1D833568000DFFAB /* BTDropInUIUtilities.m */,
+				4225EA57257EC36300923CE3 /* BTPaymentMethodNonce+DropIn.m */,
 				A56C418C1D833568000DFFAB /* BTPaymentSelectionViewController.m */,
 				A56C418D1D833568000DFFAB /* BTVaultManagementViewController.m */,
 				A56C41851D8334D7000DFFAB /* Custom Views */,
@@ -799,6 +807,7 @@
 			children = (
 				A56C41B51D83381E000DFFAB /* BTAPIClient_Internal_Category.h */,
 				A56C41B71D833A6B000DFFAB /* BTUIKBarButtonItem_Internal_Declaration.h */,
+				4225EA52257EC1EB00923CE3 /* BTPaymentMethodNonce+DropIn.h */,
 			);
 			name = "Braintree Internal Headers";
 			sourceTree = "<group>";
@@ -887,6 +896,7 @@
 				A56C41B31D8335C7000DFFAB /* BTPaymentSelectionViewController.h in Headers */,
 				8068E589256D9C68002904E6 /* BTUIKBarButtonItem_Internal_Declaration.h in Headers */,
 				A56C41AD1D8335C7000DFFAB /* BraintreeDropIn.h in Headers */,
+				4225EA53257EC1EB00923CE3 /* BTPaymentMethodNonce+DropIn.h in Headers */,
 				A56C41B41D8335C7000DFFAB /* BTVaultManagementViewController.h in Headers */,
 				A56C41AE1D8335C7000DFFAB /* BTCardFormViewController.h in Headers */,
 				A56C41B01D8335C7000DFFAB /* BTDropInController.h in Headers */,
@@ -1090,11 +1100,13 @@
 				"${PODS_ROOT}/Target Support Files/Pods-All-UnitTests/Pods-All-UnitTests-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Braintree/Braintree.framework",
 				"${PODS_ROOT}/Braintree/Frameworks/CardinalMobile.framework",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/PPRiskMagnes/PPRiskMagnes.framework/PPRiskMagnes",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Braintree.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CardinalMobile.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PPRiskMagnes.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1210,6 +1222,7 @@
 				03B793AD1DAD61B500F54B1B /* BTDropInResultTests.m in Sources */,
 				4245DAF3256C721D00F1A413 /* FakeApplication.swift in Sources */,
 				0358590B203E09E200FCE1B7 /* BTDropInRequestTests.m in Sources */,
+				4225EA87257EC59600923CE3 /* BTPaymentMethodNonce+DropInTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1221,6 +1234,7 @@
 				A56C41A01D8335BB000DFFAB /* BTDropInPaymentSeletionCell.m in Sources */,
 				A56C41941D833568000DFFAB /* BTVaultManagementViewController.m in Sources */,
 				A56C41A41D8335BB000DFFAB /* BTUIPaymentMethodCollectionViewCell.m in Sources */,
+				4225EA58257EC36300923CE3 /* BTPaymentMethodNonce+DropIn.m in Sources */,
 				A56C41921D833568000DFFAB /* BTDropInUIUtilities.m in Sources */,
 				A56C418E1D833568000DFFAB /* BTCardFormViewController.m in Sources */,
 				A56C41981D833597000DFFAB /* BTDropInResult.m in Sources */,

--- a/BraintreeDropIn.xcodeproj/project.pbxproj
+++ b/BraintreeDropIn.xcodeproj/project.pbxproj
@@ -715,18 +715,18 @@
 		A5411A1D1D8A1F090041BE92 /* UnitTests */ = {
 			isa = PBXGroup;
 			children = (
-				A5411A201D8A1F090041BE92 /* Info.plist */,
-				A50ED7A51D8AF8C400A78EF0 /* BTPaymentSelectionViewControllerTests.m */,
-				03B793AC1DAD61B500F54B1B /* BTDropInResultTests.m */,
-				0358590A203E09E200FCE1B7 /* BTDropInRequestTests.m */,
-				A50ED7A71D8B02AF00A78EF0 /* BTUIKViewUtilTests.m */,
-				A5672DAB1DC9369D0058485E /* BTUIKCardTypeTests.m */,
 				034D31991E8EEC4B0056F5AA /* BTDropInBaseViewControllerTests.m */,
-				034B5C12203CDFD0001A01DE /* BTUIKCardListLabelTests.m */,
-				425B83972347D3990015D1A4 /* BTUIKAppearanceTests.swift */,
-				42A10AD8230EE4D600892302 /* UnitTests-Bridging-Header.h */,
-				4245DAF2256C721D00F1A413 /* FakeApplication.swift */,
+				0358590A203E09E200FCE1B7 /* BTDropInRequestTests.m */,
+				03B793AC1DAD61B500F54B1B /* BTDropInResultTests.m */,
 				4225EA86257EC59600923CE3 /* BTPaymentMethodNonce+DropInTests.swift */,
+				A50ED7A51D8AF8C400A78EF0 /* BTPaymentSelectionViewControllerTests.m */,
+				425B83972347D3990015D1A4 /* BTUIKAppearanceTests.swift */,
+				034B5C12203CDFD0001A01DE /* BTUIKCardListLabelTests.m */,
+				A5672DAB1DC9369D0058485E /* BTUIKCardTypeTests.m */,
+				A50ED7A71D8B02AF00A78EF0 /* BTUIKViewUtilTests.m */,
+				4245DAF2256C721D00F1A413 /* FakeApplication.swift */,
+				A5411A201D8A1F090041BE92 /* Info.plist */,
+				42A10AD8230EE4D600892302 /* UnitTests-Bridging-Header.h */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 # Braintree iOS Drop-in SDK - Release Notes
 
-## unreleased
+## unreleased (9.0.0-beta1)
 
-* Breaking changes (v9)
+* Breaking changes
   * Bump minimum supported deployment target to iOS 12.0
   * Require Braintree ~> 5.0.0-beta
-  * Update `BTDropInResult.paymentDescription` value for Apple Pay to return last two digits of card number
 
 ## 8.1.2 (2020-11-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Breaking changes (v9)
   * Bump minimum supported deployment target to iOS 12.0
+  * Require Braintree ~> 5.0.0-beta
+  * Update `BTDropInResult.paymentDescription` value for Apple Pay to return last two digits of card number
 
 ## 8.1.2 (2020-11-30)
 

--- a/Demo/Demo Base/DemoAppDelegate.swift
+++ b/Demo/Demo Base/DemoAppDelegate.swift
@@ -15,6 +15,7 @@ class DemoAppDelegate: UIResponder, UIApplicationDelegate {
         appearanceProxy.barStyle = .blackTranslucent
 
         registerUserDefaults()
+        BTAppSwitch.setReturnURLScheme(BraintreeDemoAppDelegatePaymentsURLScheme)
         
         let rootViewController = DemoContainerViewController()
         let navigationController = UINavigationController(rootViewController: rootViewController)
@@ -26,7 +27,7 @@ class DemoAppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
         guard url.scheme?.lowercased() == BraintreeDemoAppDelegatePaymentsURLScheme.lowercased() else { return true }
-        return BTAppSwitch.handleOpen(url, options: options)
+        return BTAppSwitch.handleOpen(url)
     }
     
     private func registerUserDefaults() {
@@ -105,13 +106,7 @@ class DemoAppDelegate: UIResponder, UIApplicationDelegate {
                 UserDefaults.standard.set(testIntegration, forKey: "BraintreeDemoSettingsAuthorizationOverride")
             }
         }
-        
-        if testArguments.contains("-BadUrlScheme") {
-            BTAppSwitch.setReturnURLScheme("com.braintreepayments.bad.scheme")
-        } else {
-            BTAppSwitch.setReturnURLScheme(BraintreeDemoAppDelegatePaymentsURLScheme)
-        }
-        
+
         let settingsPlist = Bundle.main.url(forResource: "Settings", withExtension: "bundle")!.appendingPathComponent("Root.plist")
         let settingsDictionary = NSDictionary(contentsOf: settingsPlist)!
         let preferences = settingsDictionary["PreferenceSpecifiers"] as! [[String : Any]]

--- a/Demo/Demo Base/DemoDropInViewController.swift
+++ b/Demo/Demo Base/DemoDropInViewController.swift
@@ -96,7 +96,7 @@ class DemoDropInViewController: DemoBaseViewController {
                 self.progressBlock?("Ready for checkout...")
                 self.didSelectApplePay = false
                 self.selectedNonce = result.paymentMethod
-                self.updatePaymentMethodNonce(result.paymentMethod, paymentDescription: result.paymentDescription)
+                self.updatePaymentMethodNonce(result)
             }
             
             dropInController.dismiss(animated: true, completion: nil)
@@ -145,13 +145,13 @@ class DemoDropInViewController: DemoBaseViewController {
     
     // MARK: - Helper Methods
 
-    func updatePaymentMethodNonce(_ nonce: BTPaymentMethodNonce?, paymentDescription: String?) {
-        demoView.paymentMethodTypeLabel.isHidden = (nonce == nil)
-        demoView.paymentMethodTypeIcon.isHidden = (nonce == nil)
-        if let nonce = nonce {
+    func updatePaymentMethodNonce(_ result: BTDropInResult?) {
+        demoView.paymentMethodTypeLabel.isHidden = (result?.paymentMethod == nil)
+        demoView.paymentMethodTypeIcon.isHidden = (result?.paymentMethod == nil)
+        if let nonce = result?.paymentMethod {
             let paymentMethodType = BTUIKViewUtil.paymentOptionType(forPaymentInfoType: nonce.type)
             demoView.paymentMethodTypeIcon.paymentOptionType = paymentMethodType
-            demoView.paymentMethodTypeLabel.text = paymentDescription
+            demoView.paymentMethodTypeLabel.text = result?.paymentDescription
         }
         demoView.updatePaymentMethodConstraints()
     }
@@ -173,7 +173,7 @@ class DemoDropInViewController: DemoBaseViewController {
             } else {
                 self.didSelectApplePay = false
                 self.selectedNonce = result.paymentMethod
-                self.updatePaymentMethodNonce(self.selectedNonce, paymentDescription: result.paymentDescription)
+                self.updatePaymentMethodNonce(result)
             }
         }
     }

--- a/Demo/Demo Base/DemoDropInViewController.swift
+++ b/Demo/Demo Base/DemoDropInViewController.swift
@@ -96,7 +96,7 @@ class DemoDropInViewController: DemoBaseViewController {
                 self.progressBlock?("Ready for checkout...")
                 self.didSelectApplePay = false
                 self.selectedNonce = result.paymentMethod
-                self.updatePaymentMethodNonce(result.paymentMethod)
+                self.updatePaymentMethodNonce(result.paymentMethod, paymentDescription: result.paymentDescription)
             }
             
             dropInController.dismiss(animated: true, completion: nil)
@@ -133,8 +133,6 @@ class DemoDropInViewController: DemoBaseViewController {
             
             progressBlock?("Presenting Apple Pay Sheet")
             present(applePayController, animated: true)
-        } else if DemoSettings.threeDSecureRequiredStatus == .required, (selectedNonce as? BTCardNonce)?.threeDSecureInfo.wasVerified == false {
-            performThreeDSecureVerification()
         } else {
             completionBlock?(self.selectedNonce)
             transactionBlock?()
@@ -145,52 +143,15 @@ class DemoDropInViewController: DemoBaseViewController {
         DemoSettings.colorSchemeSetting = BTUIKColorScheme(rawValue: segmentedControl.selectedSegmentIndex)!
     }
     
-    // MARK: - ThreeDSecure Verification
-    
-    func performThreeDSecureVerification() {
-        guard let apiClient = BTAPIClient(authorization: authorization) else { return }
-        guard let nonce = selectedNonce?.nonce else { return }
-        
-        let threeDSecureRequest = BTThreeDSecureRequest()
-        threeDSecureRequest.amount = 10.00
-        threeDSecureRequest.nonce = nonce
-
-        let paymentFlowDriver = BTPaymentFlowDriver(apiClient: apiClient)
-        paymentFlowDriver.viewControllerPresentingDelegate = self
-        
-        paymentFlowDriver.startPaymentFlow(threeDSecureRequest) { (result, error) in
-            self.selectedNonce = nil
-            
-            if let error = error {
-                if (error as NSError).code == BTPaymentFlowDriverErrorType.canceled.rawValue {
-                    // User cancelled 3DS flow and nonce was consumed
-                } else {
-                    // An error occurred and nonce was consumed
-                }
-                self.updatePaymentMethodNonce(nil)
-                self.fetchPaymentMethods()
-                self.progressBlock?(error.localizedDescription)
-                return
-            }
-        
-            if let threeDSecureResult = result as? BTThreeDSecureResult {
-                self.selectedNonce = threeDSecureResult.tokenizedCard
-                self.updatePaymentMethodNonce(self.selectedNonce)
-                self.completionBlock?(self.selectedNonce)
-                self.transactionBlock?()
-            }
-        }
-    }
-    
     // MARK: - Helper Methods
-    
-    func updatePaymentMethodNonce(_ nonce: BTPaymentMethodNonce?) {
+
+    func updatePaymentMethodNonce(_ nonce: BTPaymentMethodNonce?, paymentDescription: String?) {
         demoView.paymentMethodTypeLabel.isHidden = (nonce == nil)
         demoView.paymentMethodTypeIcon.isHidden = (nonce == nil)
         if let nonce = nonce {
             let paymentMethodType = BTUIKViewUtil.paymentOptionType(forPaymentInfoType: nonce.type)
             demoView.paymentMethodTypeIcon.paymentOptionType = paymentMethodType
-            demoView.paymentMethodTypeLabel.text = nonce.localizedDescription
+            demoView.paymentMethodTypeLabel.text = paymentDescription
         }
         demoView.updatePaymentMethodConstraints()
     }
@@ -212,7 +173,7 @@ class DemoDropInViewController: DemoBaseViewController {
             } else {
                 self.didSelectApplePay = false
                 self.selectedNonce = result.paymentMethod
-                self.updatePaymentMethodNonce(self.selectedNonce)
+                self.updatePaymentMethodNonce(self.selectedNonce, paymentDescription: result.paymentDescription)
             }
         }
     }

--- a/Demo/Demo.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
+++ b/Demo/Demo.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
@@ -41,9 +41,19 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "# Disable hardware keyboard - https://stackoverflow.com/a/57268609&#10;killall Simulator&#10;defaults write com.apple.iphonesimulator ConnectHardwareKeyboard -bool false&#10;">
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "8068E51C256D73D5002904E6"

--- a/Demo/Demo.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
+++ b/Demo/Demo.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
@@ -41,15 +41,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <PreActions>
-         <ExecutionAction
-            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
-            <ActionContent
-               title = "Run Script"
-               scriptText = "# Disable hardware keyboard - https://stackoverflow.com/a/57268609&#10;killall Simulator&#10;defaults write com.apple.iphonesimulator ConnectHardwareKeyboard -bool false&#10;">
-            </ActionContent>
-         </ExecutionAction>
-      </PreActions>
       <Testables>
          <TestableReference
             skipped = "NO"

--- a/Demo/UITests/BraintreeDropIn_UITests.swift
+++ b/Demo/UITests/BraintreeDropIn_UITests.swift
@@ -62,9 +62,9 @@ class BraintreeDropIn_TokenizationKey_CardForm_UITests: XCTestCase {
 
         app.buttons["Add Card"].forceTapElement()
 
-        waitForElementToAppear(app.staticTexts["ending in 11"])
+        waitForElementToAppear(app.staticTexts["••• ••11"])
 
-        XCTAssertTrue(app.staticTexts["ending in 11"].exists)
+        XCTAssertTrue(app.staticTexts["••• ••11"].exists)
     }
 
     func testDropIn_cardInput_showsInvalidState_withInvalidCardNumber() {
@@ -303,9 +303,9 @@ class BraintreeDropIn_CardholderNameAvailable_UITests: XCTestCase {
 
         app.buttons["Add Card"].forceTapElement()
 
-        waitForElementToAppear(app.staticTexts["ending in 11"])
+        waitForElementToAppear(app.staticTexts["••• ••11"])
 
-        XCTAssertTrue(app.staticTexts["ending in 11"].exists)
+        XCTAssertTrue(app.staticTexts["••• ••11"].exists)
 
     }
 }
@@ -401,9 +401,9 @@ class BraintreeDropIn_CardholderNameRequired_UITests: XCTestCase {
 
         app.buttons["Add Card"].forceTapElement()
 
-        waitForElementToAppear(app.staticTexts["ending in 11"])
+        waitForElementToAppear(app.staticTexts["••• ••11"])
 
-        XCTAssertTrue(app.staticTexts["ending in 11"].exists)
+        XCTAssertTrue(app.staticTexts["••• ••11"].exists)
     }
 }
 
@@ -449,9 +449,9 @@ class BraintreeDropIn_ClientToken_CardForm_UITests: XCTestCase {
 
         app.buttons["Add Card"].forceTapElement()
 
-        waitForElementToAppear(app.staticTexts["ending in 11"])
+        waitForElementToAppear(app.staticTexts["••• ••11"])
 
-        XCTAssertTrue(app.staticTexts["ending in 11"].exists)
+        XCTAssertTrue(app.staticTexts["••• ••11"].exists)
     }
 
     func testDropIn_nonUnionPayCardNumber_showsNextButton() {
@@ -527,9 +527,9 @@ class BraintreeDropIn_ClientToken_CardForm_UITests: XCTestCase {
         waitForElementToBeHittable(app.buttons["Confirm"])
         app.buttons["Confirm"].forceTapElement()
 
-        waitForElementToAppear(app.staticTexts["ending in 32"])
+        waitForElementToAppear(app.staticTexts["••• ••32"])
 
-        XCTAssertTrue(app.staticTexts["ending in 32"].exists)
+        XCTAssertTrue(app.staticTexts["••• ••32"].exists)
     }
 
 }
@@ -739,9 +739,9 @@ class BraintreeDropIn_ThreeDSecure_UITests: XCTestCase {
 
         app.buttons["Submit"].forceTapElement()
 
-        waitForElementToAppear(app.staticTexts["ending in 11"])
+        waitForElementToAppear(app.staticTexts["••• ••11"])
 
-        XCTAssertTrue(app.staticTexts["ending in 11"].exists)
+        XCTAssertTrue(app.staticTexts["••• ••11"].exists)
 
         waitForElementToBeHittable(app.buttons["Complete Purchase"])
         app.buttons["Complete Purchase"].forceTapElement()
@@ -779,7 +779,7 @@ class BraintreeDropIn_ThreeDSecure_UITests: XCTestCase {
 
         waitForElementToAppear(app.staticTexts["Added Protection"], timeout: 20)
 
-        app.buttons["Done"].forceTapElement()
+        app.staticTexts["Cancel"].firstMatch.forceTapElement()
         waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
         waitForElementToAppear(app.staticTexts["Select Payment Method"])
 
@@ -872,9 +872,9 @@ class BraintreeDropIn_ThreeDSecure_2_UITests: XCTestCase {
 
         app.buttons["Add Card"].forceTapElement()
 
-        waitForElementToAppear(app.staticTexts["ending in 00"])
+        waitForElementToAppear(app.staticTexts["••• ••00"])
 
-        XCTAssertTrue(app.staticTexts["ending in 00"].exists)
+        XCTAssertTrue(app.staticTexts["••• ••00"].exists)
 
         waitForElementToBeHittable(app.buttons["Complete Purchase"])
         app.buttons["Complete Purchase"].forceTapElement()
@@ -920,9 +920,9 @@ class BraintreeDropIn_ThreeDSecure_2_UITests: XCTestCase {
 
         app.buttons["SUBMIT"].forceTapElement()
 
-        waitForElementToAppear(app.staticTexts["ending in 91"])
+        waitForElementToAppear(app.staticTexts["••• ••91"])
 
-        XCTAssertTrue(app.staticTexts["ending in 91"].exists)
+        XCTAssertTrue(app.staticTexts["••• ••91"].exists)
 
         waitForElementToBeHittable(app.buttons["Complete Purchase"])
         app.buttons["Complete Purchase"].forceTapElement()
@@ -1009,9 +1009,9 @@ class BraintreeDropIn_ThreeDSecure_VaultedPaymentMethod_UITests: XCTestCase {
 
         app.buttons["SUBMIT"].forceTapElement()
 
-        waitForElementToAppear(app.staticTexts["ending in 91"])
+        waitForElementToAppear(app.staticTexts["••• ••91"])
 
-        XCTAssertTrue(app.staticTexts["ending in 91"].exists)
+        XCTAssertTrue(app.staticTexts["••• ••91"].exists)
     }
 }
 
@@ -1034,34 +1034,6 @@ class BraintreeDropIn_Venmo_NotInstalled_UITests: XCTestCase {
     func testDropIn_venmo_doesNotShow_whenDisabled() {
         waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
         XCTAssertFalse(app.staticTexts["Venmo"].exists)
-    }
-}
-
-class BraintreeDropIn_Error_UITests: XCTestCase {
-
-    var app: XCUIApplication!
-
-    override func setUp() {
-        super.setUp()
-        continueAfterFailure = false
-        app = XCUIApplication()
-        app.launchArguments.append("-EnvironmentSandbox")
-        app.launchArguments.append("-TokenizationKey")
-        app.launchArguments.append("-BadUrlScheme")
-        app.launch()
-        sleep(1)
-        waitForElementToBeHittable(app.buttons["Add Payment Method"])
-        app.buttons["Add Payment Method"].tap()
-    }
-
-    func testDropIn_paypal_receivesError_whenUrlSchemeIsIncorrect() {
-        waitForElementToBeHittable(app.staticTexts["PayPal"])
-        app.staticTexts["PayPal"].tap()
-        sleep(3)
-
-        let existsPredicate = NSPredicate(format: "label LIKE '*Application does not support One Touch callback*'")
-
-        waitForElementToAppear(app.buttons.containing(existsPredicate).element(boundBy: 0))
     }
 }
 

--- a/Podfile
+++ b/Podfile
@@ -11,11 +11,12 @@ end
 
 # TODO: Can we migrate demo to use SPM?
 abstract_target 'All' do
-  pod 'Braintree/Apple-Pay'
-  pod 'Braintree/PaymentFlow'
-  pod 'Braintree/PayPal'
-  pod 'Braintree/Venmo'
-  pod 'Braintree/UnionPay'
+  pod 'Braintree/ApplePay', '~> 5.0.0-beta'
+  pod 'Braintree/PaymentFlow', '~> 5.0.0-beta'
+  pod 'Braintree/PayPal', '~> 5.0.0-beta'
+  pod 'Braintree/ThreeDSecure', '~> 5.0.0-beta'
+  pod 'Braintree/UnionPay', '~> 5.0.0-beta'
+  pod 'Braintree/Venmo', '~> 5.0.0-beta'
 
   target 'Demo' do
     project 'Demo/Demo'

--- a/Podfile
+++ b/Podfile
@@ -11,12 +11,12 @@ end
 
 # TODO: Can we migrate demo to use SPM?
 abstract_target 'All' do
-  pod 'Braintree/ApplePay', :git => 'https://github.com/braintree/braintree_ios.git', :branch => 'apple-pay-last-two'
-  pod 'Braintree/PaymentFlow', :git => 'https://github.com/braintree/braintree_ios.git', :branch => 'apple-pay-last-two'
-  pod 'Braintree/PayPal', :git => 'https://github.com/braintree/braintree_ios.git', :branch => 'apple-pay-last-two'
-  pod 'Braintree/ThreeDSecure', :git => 'https://github.com/braintree/braintree_ios.git', :branch => 'apple-pay-last-two'
-  pod 'Braintree/UnionPay', :git => 'https://github.com/braintree/braintree_ios.git', :branch => 'apple-pay-last-two'
-  pod 'Braintree/Venmo', :git => 'https://github.com/braintree/braintree_ios.git', :branch => 'apple-pay-last-two'
+  pod 'Braintree/ApplePay', '~> 5.0.0-beta'
+  pod 'Braintree/PaymentFlow', '~> 5.0.0-beta'
+  pod 'Braintree/PayPal', '~> 5.0.0-beta'
+  pod 'Braintree/ThreeDSecure', '~> 5.0.0-beta'
+  pod 'Braintree/UnionPay', '~> 5.0.0-beta'
+  pod 'Braintree/Venmo', '~> 5.0.0-beta'
 
   target 'Demo' do
     project 'Demo/Demo'

--- a/Podfile
+++ b/Podfile
@@ -11,12 +11,12 @@ end
 
 # TODO: Can we migrate demo to use SPM?
 abstract_target 'All' do
-  pod 'Braintree/ApplePay', '~> 5.0.0-beta'
-  pod 'Braintree/PaymentFlow', '~> 5.0.0-beta'
-  pod 'Braintree/PayPal', '~> 5.0.0-beta'
-  pod 'Braintree/ThreeDSecure', '~> 5.0.0-beta'
-  pod 'Braintree/UnionPay', '~> 5.0.0-beta'
-  pod 'Braintree/Venmo', '~> 5.0.0-beta'
+  pod 'Braintree/ApplePay', :git => 'https://github.com/braintree/braintree_ios.git', :branch => 'apple-pay-last-two'
+  pod 'Braintree/PaymentFlow', :git => 'https://github.com/braintree/braintree_ios.git', :branch => 'apple-pay-last-two'
+  pod 'Braintree/PayPal', :git => 'https://github.com/braintree/braintree_ios.git', :branch => 'apple-pay-last-two'
+  pod 'Braintree/ThreeDSecure', :git => 'https://github.com/braintree/braintree_ios.git', :branch => 'apple-pay-last-two'
+  pod 'Braintree/UnionPay', :git => 'https://github.com/braintree/braintree_ios.git', :branch => 'apple-pay-last-two'
+  pod 'Braintree/Venmo', :git => 'https://github.com/braintree/braintree_ios.git', :branch => 'apple-pay-last-two'
 
   target 'Demo' do
     project 'Demo/Demo'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -25,26 +25,35 @@ PODS:
   - xcbeautify (0.8.1)
 
 DEPENDENCIES:
-  - Braintree/ApplePay (~> 5.0.0-beta)
-  - Braintree/PaymentFlow (~> 5.0.0-beta)
-  - Braintree/PayPal (~> 5.0.0-beta)
-  - Braintree/ThreeDSecure (~> 5.0.0-beta)
-  - Braintree/UnionPay (~> 5.0.0-beta)
-  - Braintree/Venmo (~> 5.0.0-beta)
+  - Braintree/ApplePay (from `https://github.com/braintree/braintree_ios.git`, branch `apple-pay-last-two`)
+  - Braintree/PaymentFlow (from `https://github.com/braintree/braintree_ios.git`, branch `apple-pay-last-two`)
+  - Braintree/PayPal (from `https://github.com/braintree/braintree_ios.git`, branch `apple-pay-last-two`)
+  - Braintree/ThreeDSecure (from `https://github.com/braintree/braintree_ios.git`, branch `apple-pay-last-two`)
+  - Braintree/UnionPay (from `https://github.com/braintree/braintree_ios.git`, branch `apple-pay-last-two`)
+  - Braintree/Venmo (from `https://github.com/braintree/braintree_ios.git`, branch `apple-pay-last-two`)
   - InAppSettingsKit
   - xcbeautify
 
 SPEC REPOS:
   trunk:
-    - Braintree
     - InAppSettingsKit
     - xcbeautify
+
+EXTERNAL SOURCES:
+  Braintree:
+    :branch: apple-pay-last-two
+    :git: https://github.com/braintree/braintree_ios.git
+
+CHECKOUT OPTIONS:
+  Braintree:
+    :commit: a1c6649f1fd0267a944facbd9ef8d56b305d7685
+    :git: https://github.com/braintree/braintree_ios.git
 
 SPEC CHECKSUMS:
   Braintree: 725c991036ca072618ba1382a46537a75ff318db
   InAppSettingsKit: 988142fed825524ae44dd0d93684daf8f0358b8c
   xcbeautify: a3b03e4a38eb1a5766a83a7a3c53915a233572e3
 
-PODFILE CHECKSUM: d5528a1b407696733233bec79b8e42ed1aa7a636
+PODFILE CHECKSUM: b729401550ae40c23d725003fe9962edd6f980f6
 
 COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -25,35 +25,26 @@ PODS:
   - xcbeautify (0.8.1)
 
 DEPENDENCIES:
-  - Braintree/ApplePay (from `https://github.com/braintree/braintree_ios.git`, branch `apple-pay-last-two`)
-  - Braintree/PaymentFlow (from `https://github.com/braintree/braintree_ios.git`, branch `apple-pay-last-two`)
-  - Braintree/PayPal (from `https://github.com/braintree/braintree_ios.git`, branch `apple-pay-last-two`)
-  - Braintree/ThreeDSecure (from `https://github.com/braintree/braintree_ios.git`, branch `apple-pay-last-two`)
-  - Braintree/UnionPay (from `https://github.com/braintree/braintree_ios.git`, branch `apple-pay-last-two`)
-  - Braintree/Venmo (from `https://github.com/braintree/braintree_ios.git`, branch `apple-pay-last-two`)
+  - Braintree/ApplePay (~> 5.0.0-beta)
+  - Braintree/PaymentFlow (~> 5.0.0-beta)
+  - Braintree/PayPal (~> 5.0.0-beta)
+  - Braintree/ThreeDSecure (~> 5.0.0-beta)
+  - Braintree/UnionPay (~> 5.0.0-beta)
+  - Braintree/Venmo (~> 5.0.0-beta)
   - InAppSettingsKit
   - xcbeautify
 
 SPEC REPOS:
   trunk:
+    - Braintree
     - InAppSettingsKit
     - xcbeautify
-
-EXTERNAL SOURCES:
-  Braintree:
-    :branch: apple-pay-last-two
-    :git: https://github.com/braintree/braintree_ios.git
-
-CHECKOUT OPTIONS:
-  Braintree:
-    :commit: a1c6649f1fd0267a944facbd9ef8d56b305d7685
-    :git: https://github.com/braintree/braintree_ios.git
 
 SPEC CHECKSUMS:
   Braintree: 725c991036ca072618ba1382a46537a75ff318db
   InAppSettingsKit: 988142fed825524ae44dd0d93684daf8f0358b8c
   xcbeautify: a3b03e4a38eb1a5766a83a7a3c53915a233572e3
 
-PODFILE CHECKSUM: b729401550ae40c23d725003fe9962edd6f980f6
+PODFILE CHECKSUM: d5528a1b407696733233bec79b8e42ed1aa7a636
 
 COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,39 +1,36 @@
 PODS:
-  - Braintree/Apple-Pay (4.36.1):
+  - Braintree/ApplePay (5.0.0-beta1):
     - Braintree/Core
-  - Braintree/Card (4.36.1):
+  - Braintree/Card (5.0.0-beta1):
     - Braintree/Core
-  - Braintree/Core (4.36.1)
-  - Braintree/PaymentFlow (4.36.1):
-    - Braintree/Card
-    - Braintree/Core
-    - Braintree/PayPalOneTouch
-  - Braintree/PayPal (4.36.1):
-    - Braintree/Core
-    - Braintree/PayPalOneTouch
-  - Braintree/PayPalDataCollector (4.36.1):
-    - Braintree/Core
-    - Braintree/PayPalUtils
-  - Braintree/PayPalOneTouch (4.36.1):
+  - Braintree/Core (5.0.0-beta1)
+  - Braintree/PaymentFlow (5.0.0-beta1):
     - Braintree/Core
     - Braintree/PayPalDataCollector
-    - Braintree/PayPalUtils
-  - Braintree/PayPalUtils (4.36.1)
-  - Braintree/UnionPay (4.36.1):
+  - Braintree/PayPal (5.0.0-beta1):
+    - Braintree/Core
+    - Braintree/PayPalDataCollector
+  - Braintree/PayPalDataCollector (5.0.0-beta1):
+    - Braintree/Core
+  - Braintree/ThreeDSecure (5.0.0-beta1):
+    - Braintree/Card
+    - Braintree/PaymentFlow
+  - Braintree/UnionPay (5.0.0-beta1):
     - Braintree/Card
     - Braintree/Core
-  - Braintree/Venmo (4.36.1):
+  - Braintree/Venmo (5.0.0-beta1):
     - Braintree/Core
     - Braintree/PayPalDataCollector
   - InAppSettingsKit (3.1.2)
   - xcbeautify (0.8.1)
 
 DEPENDENCIES:
-  - Braintree/Apple-Pay
-  - Braintree/PaymentFlow
-  - Braintree/PayPal
-  - Braintree/UnionPay
-  - Braintree/Venmo
+  - Braintree/ApplePay (~> 5.0.0-beta)
+  - Braintree/PaymentFlow (~> 5.0.0-beta)
+  - Braintree/PayPal (~> 5.0.0-beta)
+  - Braintree/ThreeDSecure (~> 5.0.0-beta)
+  - Braintree/UnionPay (~> 5.0.0-beta)
+  - Braintree/Venmo (~> 5.0.0-beta)
   - InAppSettingsKit
   - xcbeautify
 
@@ -44,10 +41,10 @@ SPEC REPOS:
     - xcbeautify
 
 SPEC CHECKSUMS:
-  Braintree: f7e0e9a5030e22b8ad77e617f27ac9327d7bc004
+  Braintree: 725c991036ca072618ba1382a46537a75ff318db
   InAppSettingsKit: 988142fed825524ae44dd0d93684daf8f0358b8c
   xcbeautify: a3b03e4a38eb1a5766a83a7a3c53915a233572e3
 
-PODFILE CHECKSUM: b44fc2634b902720ee6f373304ca9555d37864be
+PODFILE CHECKSUM: d5528a1b407696733233bec79b8e42ed1aa7a636
 
 COCOAPODS: 1.10.0

--- a/Sources/BraintreeDropIn/BTDropInController.m
+++ b/Sources/BraintreeDropIn/BTDropInController.m
@@ -21,6 +21,12 @@
 #import <BraintreePaymentFlow/BraintreePaymentFlow.h>
 #endif
 
+#ifdef COCOAPODS
+#import <Braintree/BTThreeDSecureResult.h>
+#else
+#import <BraintreeThreeDSecure/BTThreeDSecureResult.h>
+#endif
+
 #define BT_ANIMATION_SLIDE_SPEED 0.35
 #define BT_ANIMATION_TRANSITION_SPEED 0.1
 #define BT_HALF_SHEET_MARGIN 5
@@ -313,7 +319,7 @@
     }];
 }
 
-- (void)onLookupComplete:(__unused BTThreeDSecureRequest *)request result:(__unused BTThreeDSecureLookup *)result next:(void (^)(void))next {
+- (void)onLookupComplete:(__unused BTThreeDSecureRequest *)request lookupResult:(__unused BTThreeDSecureResult *)result next:(void (^)(void))next {
     next();
 }
 

--- a/Sources/BraintreeDropIn/BTPaymentMethodNonce+DropIn.h
+++ b/Sources/BraintreeDropIn/BTPaymentMethodNonce+DropIn.h
@@ -1,0 +1,15 @@
+#ifdef COCOAPODS
+#import <Braintree/BraintreeCore.h>
+#else
+#import <BraintreeCore/BraintreeCore.h>
+#endif
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BTPaymentMethodNonce (DropIn)
+
+@property (nonatomic, copy, readonly) NSString *paymentDescription;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/BraintreeDropIn/BTPaymentMethodNonce+DropIn.m
+++ b/Sources/BraintreeDropIn/BTPaymentMethodNonce+DropIn.m
@@ -4,10 +4,12 @@
 #import <Braintree/BTCardNonce.h>
 #import <Braintree/BTPayPalAccountNonce.h>
 #import <Braintree/BTVenmoAccountNonce.h>
+#import <Braintree/BTApplePayCardNonce.h>
 #else
 #import <BraintreeCard/BTCardNonce.h>
 #import <BraintreePayPal/BTPayPalAccountNonce.h>
 #import <BraintreeVenmo/BTVenmoAccountNonce.h>
+#import <BraintreeApplePay/BTApplePayCardNonce.h>
 #endif
 
 @implementation BTPaymentMethodNonce (DropIn)
@@ -19,6 +21,8 @@
         return ((BTPayPalAccountNonce *)self).email;
     } else if ([self isKindOfClass:[BTVenmoAccountNonce class]]) {
         return ((BTVenmoAccountNonce *)self).username;
+    } else if ([self isKindOfClass:[BTApplePayCardNonce class]]) {
+        return [NSString stringWithFormat:@"••• ••%@", ((BTApplePayCardNonce *)self).dpanLastTwo ?: @""];
     } else {
         return @"";
     }

--- a/Sources/BraintreeDropIn/BTPaymentMethodNonce+DropIn.m
+++ b/Sources/BraintreeDropIn/BTPaymentMethodNonce+DropIn.m
@@ -1,0 +1,27 @@
+#import "BTPaymentMethodNonce+DropIn.h"
+
+#ifdef COCOAPODS
+#import <Braintree/BTCardNonce.h>
+#import <Braintree/BTPayPalAccountNonce.h>
+#import <Braintree/BTVenmoAccountNonce.h>
+#else
+#import <BraintreeCard/BTCardNonce.h>
+#import <BraintreePayPal/BTPayPalAccountNonce.h>
+#import <BraintreeVenmo/BTVenmoAccountNonce.h>
+#endif
+
+@implementation BTPaymentMethodNonce (DropIn)
+
+- (NSString *)paymentDescription {
+    if ([self isKindOfClass:[BTCardNonce class]]) {
+        return [NSString stringWithFormat:@"••• ••%@", ((BTCardNonce *)self).lastTwo ?: @""];
+    } else if ([self isKindOfClass:[BTPayPalAccountNonce class]]) {
+        return ((BTPayPalAccountNonce *)self).email;
+    } else if ([self isKindOfClass:[BTVenmoAccountNonce class]]) {
+        return ((BTVenmoAccountNonce *)self).username;
+    } else {
+        return @"";
+    }
+}
+
+@end

--- a/Sources/BraintreeDropIn/BTPaymentMethodNonce+DropIn.m
+++ b/Sources/BraintreeDropIn/BTPaymentMethodNonce+DropIn.m
@@ -22,7 +22,7 @@
     } else if ([self isKindOfClass:[BTVenmoAccountNonce class]]) {
         return ((BTVenmoAccountNonce *)self).username;
     } else if ([self isKindOfClass:[BTApplePayCardNonce class]]) {
-        return [NSString stringWithFormat:@"••• ••%@", ((BTApplePayCardNonce *)self).dpanLastTwo ?: @""];
+        return @"Apple Pay";
     } else {
         return @"";
     }

--- a/Sources/BraintreeDropIn/BTVaultManagementViewController.m
+++ b/Sources/BraintreeDropIn/BTVaultManagementViewController.m
@@ -2,6 +2,8 @@
 #import "BTDropInPaymentSeletionCell.h"
 #import "BTAPIClient_Internal_Category.h"
 #import "BTUIKBarButtonItem_Internal_Declaration.h"
+#import "BTPaymentMethodNonce+DropIn.h"
+
 #if __has_include("BraintreeCore.h")
 #import "BraintreeCore.h"
 #else
@@ -132,11 +134,8 @@ NSString *const BTGraphQLDeletePaymentMethodFromSingleUseToken = @""
 
     cell.detailLabel.text = @"";
     NSString *typeString = paymentMethod.type;
-    NSMutableAttributedString *typeWithDescription = [[NSMutableAttributedString alloc] initWithString:[NSString stringWithFormat:@"%@", paymentMethod.localizedDescription ?: @""]];
-    if ([paymentMethod isKindOfClass:[BTCardNonce class]]) {
-        typeWithDescription = [[NSMutableAttributedString alloc] initWithString:[NSString stringWithFormat:@"••• ••%@", ((BTCardNonce*)paymentMethod).lastTwo ?: @""]];
-    }
-    cell.detailLabel.attributedText = typeWithDescription;
+
+    cell.detailLabel.text = paymentMethod.paymentDescription;
     cell.label.text = [BTUIKViewUtil nameForPaymentMethodType:[BTUIKViewUtil paymentOptionTypeForPaymentInfoType:typeString]];
     cell.iconView.paymentOptionType = option;
     cell.type = option;

--- a/Sources/BraintreeDropIn/Models/BTDropInResult.m
+++ b/Sources/BraintreeDropIn/Models/BTDropInResult.m
@@ -1,5 +1,7 @@
 #import "BTDropInResult.h"
 #import "BTAPIClient_Internal_Category.h"
+#import "BTPaymentMethodNonce+DropIn.h"
+
 #if __has_include("BraintreeCore.h")
 #import "BraintreeCore.h"
 #else
@@ -43,12 +45,7 @@
 }
 
 - (NSString *)paymentDescription {
-    if (self.paymentMethod != nil) {
-        return self.paymentMethod.localizedDescription;
-    } else if (self.paymentOptionType == BTUIKPaymentOptionTypeApplePay) {
-        return BTUIKLocalizedString(BRANDING_APPLE_PAY);
-    }
-    return @"";
+    return self.paymentMethod.paymentDescription;
 }
 
 @end

--- a/Sources/BraintreeDropIn/Public/BraintreeDropIn/BTDropInRequest.h
+++ b/Sources/BraintreeDropIn/Public/BraintreeDropIn/BTDropInRequest.h
@@ -1,8 +1,16 @@
 #import <Foundation/Foundation.h>
 
-NS_ASSUME_NONNULL_BEGIN
+#ifdef COCOAPODS
+#import <Braintree/BTPostalAddress.h>
+#import <Braintree/BTPayPalRequest.h>
+#import <Braintree/BTThreeDSecureRequest.h>
+#else
+#import <BraintreeCore/BTPostalAddress.h>
+#import <BraintreePayPal/BTPayPalRequest.h>
+#import <BraintreeThreeDSecure/BTThreeDSecureRequest.h>
+#endif
 
-@class BTPostalAddress, BTPayPalRequest, BTThreeDSecureRequest;
+NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_ENUM(NSInteger, BTFormFieldSetting) {
     BTFormFieldDisabled = 0,

--- a/Sources/BraintreeDropIn/Public/BraintreeDropIn/BTDropInResult.h
+++ b/Sources/BraintreeDropIn/Public/BraintreeDropIn/BTDropInResult.h
@@ -22,7 +22,7 @@ typedef void (^BTDropInResultFetchHandler)(BTDropInResult * _Nullable result, NS
 /// A UIView (BTUIKPaymentOptionCardView) that represents the payment option
 @property (nonatomic, readonly) UIView *paymentIcon;
 
-/// A description of the payment option (e.g `ending in 1234`)
+/// A description of the payment option (e.g `••• ••11`)
 @property (nonatomic, readonly) NSString *paymentDescription;
 
 /// The payment method nonce

--- a/UnitTests/BTDropInRequestTests.m
+++ b/UnitTests/BTDropInRequestTests.m
@@ -1,9 +1,10 @@
 #import <XCTest/XCTest.h>
 
-#import "BTDropInRequest.h"
-#import "BTPostalAddress.h"
-#import "BraintreePayPal.h"
-#import "BraintreePaymentFlow.h"
+#import <BraintreeDropIn/BTDropInRequest.h>
+#import <Braintree/BTPostalAddress.h>
+#import <Braintree/BraintreePayPal.h>
+#import <Braintree/BraintreePaymentFlow.h>
+#import <Braintree/BraintreeThreeDSecure.h>
 
 @interface BTDropInRequestTests : XCTestCase
 

--- a/UnitTests/BTPaymentMethodNonce+DropInTests.swift
+++ b/UnitTests/BTPaymentMethodNonce+DropInTests.swift
@@ -61,37 +61,9 @@ class BTPaymentMethodNonceDropInTests: XCTestCase {
         XCTAssertEqual("username@example.com", venmoNonce?.paymentDescription)
     }
 
-    func testPaymentDescription_whenApplePayNonceWithLastTwo() {
-        let sharedParser = BTPaymentMethodNonceParser.shared()
-
-        let applePayCard = BTJSON(value: [
-            "details": [
-                "cardType": "Visa",
-                "dpanLastTwo": "11"
-            ],
-            "nonce": "a-nonce",
-            "type": "ApplePayCard",
-        ])
-
-        let applePayNonce = sharedParser.parseJSON(applePayCard, withParsingBlockForType: "ApplePayCard") as? BTApplePayCardNonce
-
-        XCTAssertEqual("••• ••11", applePayNonce?.paymentDescription)
-    }
-
-    func testPaymentDescription_whenApplePayNonceWithoutLastTwo() {
-        let sharedParser = BTPaymentMethodNonceParser.shared()
-
-        let applePayCard = BTJSON(value: [
-            "details": [
-                "cardType": "Visa"
-            ],
-            "nonce": "a-nonce",
-            "type": "ApplePayCard",
-        ])
-
-        let applePayNonce = sharedParser.parseJSON(applePayCard, withParsingBlockForType: "ApplePayCard") as? BTApplePayCardNonce
-
-        XCTAssertEqual("••• ••", applePayNonce?.paymentDescription)
+    func testPaymentDescription_whenApplePay() {
+        let applePayNonce = BTApplePayCardNonce()
+        XCTAssertEqual("Apple Pay", applePayNonce.paymentDescription)
     }
 
     func testPaymentDescription_whenUnknownNonce() {

--- a/UnitTests/BTPaymentMethodNonce+DropInTests.swift
+++ b/UnitTests/BTPaymentMethodNonce+DropInTests.swift
@@ -6,7 +6,6 @@ class BTPaymentMethodNonceDropInTests: XCTestCase {
 
     let sharedParser = BTPaymentMethodNonceParser.shared()
 
-    // TODO: - Why three dots + space + two dots + last two? Should it start w/ four dots?
     func testPaymentDescription_whenCardNonceWithLastTwo() {
         let cardJSON = BTJSON(value: [
             "nonce": "fake-nonce",
@@ -21,7 +20,6 @@ class BTPaymentMethodNonceDropInTests: XCTestCase {
         XCTAssertEqual("••• ••11", cardNonce?.paymentDescription)
     }
 
-    // TODO: - check how other SDKs handle cards w/o last two digits
     func testPaymentDescription_whenCardNonceWithoutLastTwo() {
         let cardJSON = BTJSON(value: [
             "nonce": "fake-nonce",
@@ -63,17 +61,37 @@ class BTPaymentMethodNonceDropInTests: XCTestCase {
         XCTAssertEqual("username@example.com", venmoNonce?.paymentDescription)
     }
 
-    // TODO: - We need to expose the description on BTApplePayCardNonce, use a different value or hard-code the string in Drop-in
-    func testPaymentDescription_whenApplePayNonce() {
+    func testPaymentDescription_whenApplePayNonceWithLastTwo() {
         let sharedParser = BTPaymentMethodNonceParser.shared()
+
         let applePayCard = BTJSON(value: [
-            "nonce": "fake-nonce",
-            "description": "Apple Pay"
+            "details": [
+                "cardType": "Visa",
+                "dpanLastTwo": "11"
+            ],
+            "nonce": "a-nonce",
+            "type": "ApplePayCard",
         ])
 
         let applePayNonce = sharedParser.parseJSON(applePayCard, withParsingBlockForType: "ApplePayCard") as? BTApplePayCardNonce
 
-        XCTAssertEqual("Apple Pay", applePayNonce?.paymentDescription)
+        XCTAssertEqual("••• ••11", applePayNonce?.paymentDescription)
+    }
+
+    func testPaymentDescription_whenApplePayNonceWithoutLastTwo() {
+        let sharedParser = BTPaymentMethodNonceParser.shared()
+
+        let applePayCard = BTJSON(value: [
+            "details": [
+                "cardType": "Visa"
+            ],
+            "nonce": "a-nonce",
+            "type": "ApplePayCard",
+        ])
+
+        let applePayNonce = sharedParser.parseJSON(applePayCard, withParsingBlockForType: "ApplePayCard") as? BTApplePayCardNonce
+
+        XCTAssertEqual("••• ••", applePayNonce?.paymentDescription)
     }
 
     func testPaymentDescription_whenUnknownNonce() {

--- a/UnitTests/BTPaymentMethodNonce+DropInTests.swift
+++ b/UnitTests/BTPaymentMethodNonce+DropInTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+import Braintree
+import BraintreeDropIn
+
+class BTPaymentMethodNonceDropInTests: XCTestCase {
+
+    let sharedParser = BTPaymentMethodNonceParser.shared()
+
+    // TODO: - Why three dots + space + two dots + last two? Should it start w/ four dots?
+    func testPaymentDescription_whenCardNonceWithLastTwo() {
+        let cardJSON = BTJSON(value: [
+            "nonce": "fake-nonce",
+            "description": "Visa ending in 11",
+            "details": [
+                "lastTwo" : "11",
+                "cardType": "visa"
+            ]
+        ])
+        let cardNonce = sharedParser.parseJSON(cardJSON, withParsingBlockForType: "CreditCard") as? BTCardNonce
+
+        XCTAssertEqual("••• ••11", cardNonce?.paymentDescription)
+    }
+
+    // TODO: - check how other SDKs handle cards w/o last two digits
+    func testPaymentDescription_whenCardNonceWithoutLastTwo() {
+        let cardJSON = BTJSON(value: [
+            "nonce": "fake-nonce",
+            "description": "Visa ending in 11",
+            "details": [
+                "cardType": "visa"
+            ]
+        ])
+        let cardNonce = sharedParser.parseJSON(cardJSON, withParsingBlockForType: "CreditCard") as? BTCardNonce
+
+        XCTAssertEqual("••• ••", cardNonce?.paymentDescription)
+    }
+
+    func testPaymentDescription_whenPayPalNonce() {
+        let payPalJSON = BTJSON(value: [
+            "nonce": "fake-nonce",
+            "description": "A description",
+            "details": [
+                "email": "hello@world.com"
+            ]
+        ])
+
+        let payPalNonce = sharedParser.parseJSON(payPalJSON, withParsingBlockForType: "PayPalAccount") as? BTPayPalAccountNonce
+
+        XCTAssertEqual("hello@world.com", payPalNonce?.paymentDescription)
+    }
+
+    func testPaymentDescription_whenVenmoNonce() {
+        let venmoJSON = BTJSON(value: [
+            "nonce": "fake-nonce",
+            "description": "Venmo account",
+            "details": [
+                "username": "username@example.com",
+            ]
+        ])
+
+        let venmoNonce = sharedParser.parseJSON(venmoJSON, withParsingBlockForType: "VenmoAccount") as? BTVenmoAccountNonce
+
+        XCTAssertEqual("username@example.com", venmoNonce?.paymentDescription)
+    }
+
+    // TODO: - We need to expose the description on BTApplePayCardNonce, use a different value or hard-code the string in Drop-in
+    func testPaymentDescription_whenApplePayNonce() {
+        let sharedParser = BTPaymentMethodNonceParser.shared()
+        let applePayCard = BTJSON(value: [
+            "nonce": "fake-nonce",
+            "description": "Apple Pay"
+        ])
+
+        let applePayNonce = sharedParser.parseJSON(applePayCard, withParsingBlockForType: "ApplePayCard") as? BTApplePayCardNonce
+
+        XCTAssertEqual("Apple Pay", applePayNonce?.paymentDescription)
+    }
+
+    func testPaymentDescription_whenUnknownNonce() {
+        let unknownNonce = BTPaymentMethodNonce()
+        XCTAssertEqual("", unknownNonce.paymentDescription)
+    }
+}

--- a/UnitTests/UnitTests-Bridging-Header.h
+++ b/UnitTests/UnitTests-Bridging-Header.h
@@ -3,3 +3,4 @@
 //
 
 #import "BraintreeDropIn.h"
+#import "BTPaymentMethodNonce+DropIn.h"


### PR DESCRIPTION
### Summary of changes
- Update Drop-in to use v5.0.0-beta1 of `braintree_ios`

 ### Checklist
 - [X] Added a changelog entry

### Authors
@scannillo @sestevens 