### PR TITLE
Update Apple Pay

### DIFF
--- a/Sources/BraintreeDropIn/BTPaymentSelectionViewController.m
+++ b/Sources/BraintreeDropIn/BTPaymentSelectionViewController.m
@@ -25,10 +25,8 @@
 #endif
 
 #if __has_include("BraintreeApplePay.h")
-#define __BT_APPLE_PAY
 #import "BraintreeApplePay.h"
 #elif __has_include(<BraintreeApplePay/BraintreeApplePay.h>)
-#define __BT_APPLE_PAY
 #import <BraintreeApplePay/BraintreeApplePay.h>
 #endif
 
@@ -250,12 +248,9 @@ static BOOL _vaultedCardAppearAnalyticSent = NO;
                 }
             }
 
-#ifdef __BT_APPLE_PAY
-            BTJSON *applePayConfiguration = self.configuration.json[@"applePay"];
-            if ([applePayConfiguration[@"status"] isString] && ![[applePayConfiguration[@"status"] asString] isEqualToString:@"off"] && !self.dropInRequest.applePayDisabled && self.configuration.canMakeApplePayPayments) {
+            if (self.configuration.isApplePayEnabled && !self.dropInRequest.applePayDisabled && self.configuration.canMakeApplePayPayments) {
                 [activePaymentOptions addObject:@(BTUIKPaymentOptionTypeApplePay)];
             }
-#endif
 
             self.paymentOptionsData = [activePaymentOptions copy];
             [self.savedPaymentMethodsCollectionView reloadData];
@@ -509,7 +504,7 @@ static BOOL _vaultedCardAppearAnalyticSent = NO;
                 [self.delegate selectionCompletedWithPaymentMethodType:BTUIKPaymentOptionTypeVenmo nonce:paymentMethodNonce error:error];
             }
         }];
-    } else if(cell.type == BTUIKPaymentOptionTypeApplePay) {
+    } else if (cell.type == BTUIKPaymentOptionTypeApplePay) {
         if (self.delegate) {
             [self.delegate selectionCompletedWithPaymentMethodType:BTUIKPaymentOptionTypeApplePay nonce:nil error:nil];
         }

--- a/Sources/BraintreeDropIn/Public/BraintreeDropIn/BraintreeDropIn.h
+++ b/Sources/BraintreeDropIn/Public/BraintreeDropIn/BraintreeDropIn.h
@@ -6,7 +6,6 @@ FOUNDATION_EXPORT double BraintreeDropInVersionNumber;
 //! Project version string for BraintreeUI.
 FOUNDATION_EXPORT const unsigned char BraintreeDropInVersionString[];
 
-// TODO: Investigate how BraintreeDropIn exposes BraintreeCard & BraintreeCore, since they aren't listed here.
 #ifdef COCOAPODS
 #import <Braintree/BraintreeApplePay.h>
 #import <Braintree/BraintreeUnionPay.h>


### PR DESCRIPTION


### Summary of changes

 - Remove `__BT_APPLE_PAY` macro now that BraintreeApplePay is required
 - Use `isApplePayEnabled` property on `BTConfiguration`
 - Remove unneeded TODO

 ### Checklist

 - ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @scannillo
- @sestevens 
