### PR TITLE
Fix localization for Carthage integrations

### DIFF
--- a/BraintreeUIKit/Localization/BTUIKLocalizedString.m
+++ b/BraintreeUIKit/Localization/BTUIKLocalizedString.m
@@ -5,7 +5,6 @@
 static NSArray *customTranslations;
 
 + (NSBundle *)localizationBundle {
-    static NSString * bundleName = @"Braintree-UIKit-Localization";
     if ([[NSLocale preferredLanguages] count] > 0) {
         NSString *language = [[NSLocale preferredLanguages] firstObject];
         // Ignore region portion of local ID
@@ -16,9 +15,10 @@ static NSArray *customTranslations;
         }
     }
 
+    NSString *bundleName = @"Braintree-UIKit-Localization";
     NSString *localizationBundlePath = [[NSBundle mainBundle] pathForResource:bundleName ofType:@"bundle"];
     if (!localizationBundlePath) {
-        localizationBundlePath = [[NSBundle bundleForClass:[self class]] pathForResource:bundleName ofType:@"bundle"];
+        localizationBundlePath = [[NSBundle bundleForClass:self.class] pathForResource:bundleName ofType:@"bundle"];
     }
 
     // CocoaPods creates "Braintree-UIKit-Localization.bundle", so we check for that first.

--- a/BraintreeUIKit/Localization/BTUIKLocalizedString.m
+++ b/BraintreeUIKit/Localization/BTUIKLocalizedString.m
@@ -20,8 +20,10 @@ static NSArray *customTranslations;
     if (!localizationBundlePath) {
         localizationBundlePath = [[NSBundle bundleForClass:[self class]] pathForResource:bundleName ofType:@"bundle"];
     }
-    
-    return localizationBundlePath ? [NSBundle bundleWithPath:localizationBundlePath] : [NSBundle mainBundle];
+
+    // CocoaPods creates "Braintree-UIKit-Localization.bundle", so we check for that first.
+    // If not found, use the BraintreeUIKit bundle, which is where Carthage will find the localized strings.
+    return localizationBundlePath ? [NSBundle bundleWithPath:localizationBundlePath] : [NSBundle bundleForClass:self.class];
 }
 
 + (NSString *)localizationTable {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS Drop-in SDK - Release Notes
 
+## unreleased
+
+* Fix localizations for Carthage integrations (fixes #272)
+
 ## 8.1.2 (2020-11-30)
 
 * Exclude arm64 simulator architectures via Podspec (fixes #233)


### PR DESCRIPTION


### Summary of changes

 - Fix localization for Carthage integrations. See #272. Carthage will find the localization files in the current bundle, rather than in `Braintree-UIKit-Localization`, which is [specific to CocoaPods](https://github.com/braintree/braintree-ios-drop-in/blob/4167bce035b3d707db79a791ea6be74092f9f85a/BraintreeDropIn.podspec#L43).

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @scannillo 
- @sestevens 
