### PR TITLE
Show last four digits of vaulted cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
     * `BTVaultManagementViewController`
   * Add `BTDropInUICustomization`, which replaces `BTUIKAppearance` for customizing UI
   * Enable dynamic type by default. This can be disabled with the `disableDynamicType` property on `BTDropInUICustomization`.
+  * Show last four digits of vaulted cards, instead of "••• ••11", which truncates in larger fonts.
 
 ## 8.1.2 (2020-11-30)
 

--- a/Demo/UITests/BraintreeDropIn_UITests.swift
+++ b/Demo/UITests/BraintreeDropIn_UITests.swift
@@ -62,9 +62,9 @@ class BraintreeDropIn_TokenizationKey_CardForm_UITests: XCTestCase {
 
         app.buttons["Add Card"].forceTapElement()
 
-        waitForElementToAppear(app.staticTexts["••• ••11"])
+        waitForElementToAppear(app.staticTexts["1111"])
 
-        XCTAssertTrue(app.staticTexts["••• ••11"].exists)
+        XCTAssertTrue(app.staticTexts["1111"].exists)
     }
 
     func testDropIn_cardInput_showsInvalidState_withInvalidCardNumber() {
@@ -303,9 +303,9 @@ class BraintreeDropIn_CardholderNameAvailable_UITests: XCTestCase {
 
         app.buttons["Add Card"].forceTapElement()
 
-        waitForElementToAppear(app.staticTexts["••• ••11"])
+        waitForElementToAppear(app.staticTexts["1111"])
 
-        XCTAssertTrue(app.staticTexts["••• ••11"].exists)
+        XCTAssertTrue(app.staticTexts["1111"].exists)
 
     }
 }
@@ -401,9 +401,9 @@ class BraintreeDropIn_CardholderNameRequired_UITests: XCTestCase {
 
         app.buttons["Add Card"].forceTapElement()
 
-        waitForElementToAppear(app.staticTexts["••• ••11"])
+        waitForElementToAppear(app.staticTexts["1111"])
 
-        XCTAssertTrue(app.staticTexts["••• ••11"].exists)
+        XCTAssertTrue(app.staticTexts["1111"].exists)
     }
 }
 
@@ -449,9 +449,9 @@ class BraintreeDropIn_ClientToken_CardForm_UITests: XCTestCase {
 
         app.buttons["Add Card"].forceTapElement()
 
-        waitForElementToAppear(app.staticTexts["••• ••11"])
+        waitForElementToAppear(app.staticTexts["1111"])
 
-        XCTAssertTrue(app.staticTexts["••• ••11"].exists)
+        XCTAssertTrue(app.staticTexts["1111"].exists)
     }
 
     func testDropIn_nonUnionPayCardNumber_showsNextButton() {
@@ -739,9 +739,9 @@ class BraintreeDropIn_ThreeDSecure_UITests: XCTestCase {
 
         app.buttons["Submit"].forceTapElement()
 
-        waitForElementToAppear(app.staticTexts["••• ••11"])
+        waitForElementToAppear(app.staticTexts["1111"])
 
-        XCTAssertTrue(app.staticTexts["••• ••11"].exists)
+        XCTAssertTrue(app.staticTexts["1111"].exists)
 
         waitForElementToBeHittable(app.buttons["Complete Purchase"])
         app.buttons["Complete Purchase"].forceTapElement()

--- a/Demo/UITests/BraintreeDropIn_UITests.swift
+++ b/Demo/UITests/BraintreeDropIn_UITests.swift
@@ -527,9 +527,9 @@ class BraintreeDropIn_ClientToken_CardForm_UITests: XCTestCase {
         waitForElementToBeHittable(app.buttons["Confirm"])
         app.buttons["Confirm"].forceTapElement()
 
-        waitForElementToAppear(app.staticTexts["••• ••32"])
+        waitForElementToAppear(app.staticTexts["1232"])
 
-        XCTAssertTrue(app.staticTexts["••• ••32"].exists)
+        XCTAssertTrue(app.staticTexts["1232"].exists)
     }
 
 }
@@ -872,9 +872,9 @@ class BraintreeDropIn_ThreeDSecure_2_UITests: XCTestCase {
 
         app.buttons["Add Card"].forceTapElement()
 
-        waitForElementToAppear(app.staticTexts["••• ••00"])
+        waitForElementToAppear(app.staticTexts["1000"])
 
-        XCTAssertTrue(app.staticTexts["••• ••00"].exists)
+        XCTAssertTrue(app.staticTexts["1000"].exists)
 
         waitForElementToBeHittable(app.buttons["Complete Purchase"])
         app.buttons["Complete Purchase"].forceTapElement()
@@ -920,9 +920,9 @@ class BraintreeDropIn_ThreeDSecure_2_UITests: XCTestCase {
 
         app.buttons["SUBMIT"].forceTapElement()
 
-        waitForElementToAppear(app.staticTexts["••• ••91"])
+        waitForElementToAppear(app.staticTexts["1091"])
 
-        XCTAssertTrue(app.staticTexts["••• ••91"].exists)
+        XCTAssertTrue(app.staticTexts["1091"].exists)
 
         waitForElementToBeHittable(app.buttons["Complete Purchase"])
         app.buttons["Complete Purchase"].forceTapElement()
@@ -1009,9 +1009,9 @@ class BraintreeDropIn_ThreeDSecure_VaultedPaymentMethod_UITests: XCTestCase {
 
         app.buttons["SUBMIT"].forceTapElement()
 
-        waitForElementToAppear(app.staticTexts["••• ••91"])
+        waitForElementToAppear(app.staticTexts["1091"])
 
-        XCTAssertTrue(app.staticTexts["••• ••91"].exists)
+        XCTAssertTrue(app.staticTexts["1091"].exists)
     }
 }
 

--- a/Sources/BraintreeDropIn/BTPaymentMethodNonce+DropIn.m
+++ b/Sources/BraintreeDropIn/BTPaymentMethodNonce+DropIn.m
@@ -16,7 +16,7 @@
 
 - (NSString *)paymentDescription {
     if ([self isKindOfClass:[BTCardNonce class]]) {
-        return [NSString stringWithFormat:@"••• ••%@", ((BTCardNonce *)self).lastTwo ?: @""];
+        return ((BTCardNonce *)self).lastFour;
     } else if ([self isKindOfClass:[BTPayPalAccountNonce class]]) {
         return ((BTPayPalAccountNonce *)self).email;
     } else if ([self isKindOfClass:[BTVenmoAccountNonce class]]) {

--- a/Sources/BraintreeDropIn/BTVaultManagementViewController.m
+++ b/Sources/BraintreeDropIn/BTVaultManagementViewController.m
@@ -129,11 +129,8 @@ NSString *const BTGraphQLDeletePaymentMethodFromSingleUseToken = @""
     BTPaymentMethodNonce *paymentMethod = self.paymentMethodNonces[indexPath.row];
     BTUIKPaymentOptionType option = [BTUIKViewUtil paymentOptionTypeForPaymentInfoType:paymentMethod.type];
 
-    cell.detailLabel.text = @"";
-    NSString *typeString = paymentMethod.type;
-
     cell.detailLabel.text = paymentMethod.paymentDescription;
-    cell.label.text = [BTUIKViewUtil nameForPaymentMethodType:[BTUIKViewUtil paymentOptionTypeForPaymentInfoType:typeString]];
+    cell.label.text = [BTUIKViewUtil nameForPaymentMethodType:option];
     cell.iconView.paymentOptionType = option;
     cell.type = option;
 

--- a/Sources/BraintreeDropIn/Custom Views/BTDropInPaymentSeletionCell.m
+++ b/Sources/BraintreeDropIn/Custom Views/BTDropInPaymentSeletionCell.m
@@ -30,7 +30,6 @@
         self.label = [[UILabel alloc] init];
         [BTUIKAppearance styleLabelPrimary:self.label];
         self.label.translatesAutoresizingMaskIntoConstraints = NO;
-        self.label.numberOfLines = 0;
         [self.labelContainer addSubview:self.label];
 
         self.detailLabel = [[UILabel alloc] init];
@@ -77,7 +76,7 @@
     NSDictionary* viewBindings = @{@"contentView":self.contentView, @"label":self.label, @"iconView":self.iconView, @"bottomBorder":self.bottomBorder, @"detailLabel":self.detailLabel, @"labelContainer":self.labelContainer};
 
     [self.label.topAnchor constraintEqualToAnchor:self.contentView.layoutMarginsGuide.topAnchor].active = YES;
-    [self.label.bottomAnchor constraintEqualToAnchor:self.contentView.layoutMarginsGuide.bottomAnchor].active = YES;
+    [self.detailLabel.bottomAnchor constraintEqualToAnchor:self.contentView.layoutMarginsGuide.bottomAnchor].active = YES;
 
     [self.labelContainer addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[label][detailLabel]|"
                                                                              options:0
@@ -120,7 +119,7 @@
                                                                 multiplier:1.0f
                                                                   constant:0.0f]];
 
-    [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-(HORIZONTAL_FORM_PADDING)-[iconView(ICON_WIDTH)]-(HORIZONTAL_FORM_PADDING)-[labelContainer]|"
+    [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-(HORIZONTAL_FORM_PADDING)-[iconView(ICON_WIDTH)]-(HORIZONTAL_FORM_PADDING)-[labelContainer]-|"
                                                                              options:0
                                                                              metrics:[BTUIKAppearance metrics]
                                                                                views:viewBindings]];

--- a/Sources/BraintreeDropIn/Public/BraintreeDropIn/BTDropInResult.h
+++ b/Sources/BraintreeDropIn/Public/BraintreeDropIn/BTDropInResult.h
@@ -23,7 +23,13 @@ typedef void (^BTDropInResultFetchHandler)(BTDropInResult * _Nullable result, NS
 /// A UIView (BTUIKPaymentOptionCardView) that represents the payment option
 @property (nonatomic, readonly) UIView *paymentIcon;
 
-/// A description of the payment option (e.g `••• ••11`)
+/**
+ * A description of the payment option.
+ * For cards, the last four digits of the card number.
+ * For PayPal, the email address associated with the account.
+ * For Venmo, the username associated with the account.
+ * For Apple Pay, the text "Apple Pay".
+ */
 @property (nonatomic, readonly) NSString *paymentDescription;
 
 /// The payment method nonce

--- a/UnitTests/BTPaymentMethodNonce+DropInTests.swift
+++ b/UnitTests/BTPaymentMethodNonce+DropInTests.swift
@@ -3,20 +3,14 @@ import BraintreeDropIn
 
 class BTPaymentMethodNonce_DropInTests: XCTestCase {
 
-    func testPaymentDescription_whenCardNonceWithLastTwo() {
+    func testPaymentDescription_whenCardNonceWithLastFour() {
         class MockCardNonce: BTCardNonce {
-            override var lastTwo: String? { "11" }
+            override var lastFour: String? { "1111" }
         }
 
         let cardNonce = MockCardNonce()
 
-        XCTAssertEqual("••• ••11", cardNonce.paymentDescription)
-    }
-
-    func testPaymentDescription_whenCardNonceWithoutLastTwo() {
-        let cardNonce = BTCardNonce()
-
-        XCTAssertEqual("••• ••", cardNonce.paymentDescription)
+        XCTAssertEqual("1111", cardNonce.paymentDescription)
     }
 
     func testPaymentDescription_whenPayPalNonce() {


### PR DESCRIPTION


### Summary of changes

* Show last four digits of card number instead of "••• ••11". This prevents the important info (the digits) from truncating when a large font size is used.

This change applies to:
* Payment method selection screen (when vaulted payment methods are shown)
* Vault manager screen




 ### Checklist

 - [x] Added a changelog entry

### Authors
-@sestevens

### Screenshots

*Payment method selection screen:*

![Simulator Screen Shot - iPhone 12 - 2021-03-01 at 17 17 42](https://user-images.githubusercontent.com/51723734/109572030-28127e00-7ab2-11eb-8bd8-6c234ae0d00e.png)

----------------

*Vault manager screen:*

![Simulator Screen Shot - iPhone 12 - 2021-03-01 at 17 17 49](https://user-images.githubusercontent.com/51723734/109572031-28ab1480-7ab2-11eb-9bf1-6126ffff70d0.png)

