### PR TITLE
Add Build workflow to GH Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Use Xcode 12.4
         run: sudo xcode-select -switch /Applications/Xcode_12.4.app
-      - name: Install CocoaPod dependencies
-        run: pod install
       - name: Run pod lib lint
         run: pod lib lint
   spm:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Build
+on: [pull_request, workflow_dispatch]
+jobs:
+  cocoapods:
+    name: CocoaPods
+    runs-on: macOS-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Use Xcode 12.4
+        run: sudo xcode-select -switch /Applications/Xcode_12.4.app
+      - name: Install CocoaPod dependencies
+        run: pod install
+      - name: Run pod lib lint
+        run: pod lib lint
+  spm:
+    name: SPM
+    runs-on: macOS-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Use Xcode 12.4
+        run: sudo xcode-select -switch /Applications/Xcode_12.4.app
+      - name: Use current branch
+        run: sed -i '' 's/branch = .*/branch = \"'"$GITHUB_HEAD_REF"'\";/' SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
+      - name: Run swift package resolve
+        run: cd SampleApps/SPMTest && swift package resolve
+      - name: Build & archive SPMTest
+        run: xcodebuild -project 'SampleApps/SPMTest/SPMTest.xcodeproj' -scheme 'SPMTest' clean build archive CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,11 +9,10 @@ jobs:
     name: Unit
     runs-on: macOS-latest
     steps:
-      # Checks out a copy of your repository
       - name: Checkout repository
-        uses: actions/checkout@v1
-      - name: Use Xcode 12.3
-        run: sudo xcode-select -switch /Applications/Xcode_12.3.app
+        uses: actions/checkout@v2
+      - name: Use Xcode 12.4
+        run: sudo xcode-select -switch /Applications/Xcode_12.4.app
       - name: Install xcpretty
         run: gem install xcpretty
       - name: Cache Carthage dependencies
@@ -31,11 +30,10 @@ jobs:
     name: UI
     runs-on: macOS-latest
     steps:
-      # Checks out a copy of your repository
       - name: Checkout repository
-        uses: actions/checkout@v1
-      - name: Use Xcode 12.3
-        run: sudo xcode-select -switch /Applications/Xcode_12.3.app
+        uses: actions/checkout@v2
+      - name: Use Xcode 12.4
+        run: sudo xcode-select -switch /Applications/Xcode_12.4.app
       - name: Install xcpretty
         run: gem install xcpretty
       - name: Cache Carthage dependencies

--- a/SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
+++ b/SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		428DB19025F2C49E00B7EF7E /* BraintreeUIKit in Frameworks */ = {isa = PBXBuildFile; productRef = 428DB18F25F2C49E00B7EF7E /* BraintreeUIKit */; };
+		428DB19225F2C49E00B7EF7E /* BraintreeDropIn in Frameworks */ = {isa = PBXBuildFile; productRef = 428DB19125F2C49E00B7EF7E /* BraintreeDropIn */; };
 		800FC588257FF3E000DEE132 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800FC587257FF3E000DEE132 /* AppDelegate.swift */; };
 		800FC58A257FF3E000DEE132 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800FC589257FF3E000DEE132 /* SceneDelegate.swift */; };
 		800FC58C257FF3E000DEE132 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800FC58B257FF3E000DEE132 /* ViewController.swift */; };
@@ -15,8 +17,6 @@
 		800FC594257FF3E200DEE132 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 800FC592257FF3E200DEE132 /* LaunchScreen.storyboard */; };
 		80A8C40A25A8CF91003A68F5 /* CardinalMobile.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80A8C40825A8CF90003A68F5 /* CardinalMobile.framework */; };
 		80A8C40B25A8CF91003A68F5 /* CardinalMobile.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 80A8C40825A8CF90003A68F5 /* CardinalMobile.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		80D57F3225BA2ECC0087046B /* BraintreeUIKit in Frameworks */ = {isa = PBXBuildFile; productRef = 80D57F3125BA2ECC0087046B /* BraintreeUIKit */; };
-		80D57F3425BA2ECC0087046B /* BraintreeDropIn in Frameworks */ = {isa = PBXBuildFile; productRef = 80D57F3325BA2ECC0087046B /* BraintreeDropIn */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -50,9 +50,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				80D57F3225BA2ECC0087046B /* BraintreeUIKit in Frameworks */,
+				428DB19025F2C49E00B7EF7E /* BraintreeUIKit in Frameworks */,
 				80A8C40A25A8CF91003A68F5 /* CardinalMobile.framework in Frameworks */,
-				80D57F3425BA2ECC0087046B /* BraintreeDropIn in Frameworks */,
+				428DB19225F2C49E00B7EF7E /* BraintreeDropIn in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -116,8 +116,8 @@
 			);
 			name = SPMTest;
 			packageProductDependencies = (
-				80D57F3125BA2ECC0087046B /* BraintreeUIKit */,
-				80D57F3325BA2ECC0087046B /* BraintreeDropIn */,
+				428DB18F25F2C49E00B7EF7E /* BraintreeUIKit */,
+				428DB19125F2C49E00B7EF7E /* BraintreeDropIn */,
 			);
 			productName = SPMTest;
 			productReference = 800FC584257FF3E000DEE132 /* SPMTest.app */;
@@ -147,7 +147,7 @@
 			);
 			mainGroup = 800FC57B257FF3E000DEE132;
 			packageReferences = (
-				80D57F3025BA2ECC0087046B /* XCRemoteSwiftPackageReference "braintree-ios-drop-in" */,
+				428DB18E25F2C49E00B7EF7E /* XCRemoteSwiftPackageReference "braintree-ios-drop-in" */,
 			);
 			productRefGroup = 800FC585257FF3E000DEE132 /* Products */;
 			projectDirPath = "";
@@ -392,9 +392,9 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		80D57F3025BA2ECC0087046B /* XCRemoteSwiftPackageReference "braintree-ios-drop-in" */ = {
+		428DB18E25F2C49E00B7EF7E /* XCRemoteSwiftPackageReference "braintree-ios-drop-in" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "git@github.com:braintree/braintree-ios-drop-in.git";
+			repositoryURL = "https://github.com/braintree/braintree-ios-drop-in.git";
 			requirement = {
 				branch = "next-major-version";
 				kind = branch;
@@ -403,14 +403,14 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		80D57F3125BA2ECC0087046B /* BraintreeUIKit */ = {
+		428DB18F25F2C49E00B7EF7E /* BraintreeUIKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 80D57F3025BA2ECC0087046B /* XCRemoteSwiftPackageReference "braintree-ios-drop-in" */;
+			package = 428DB18E25F2C49E00B7EF7E /* XCRemoteSwiftPackageReference "braintree-ios-drop-in" */;
 			productName = BraintreeUIKit;
 		};
-		80D57F3325BA2ECC0087046B /* BraintreeDropIn */ = {
+		428DB19125F2C49E00B7EF7E /* BraintreeDropIn */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 80D57F3025BA2ECC0087046B /* XCRemoteSwiftPackageReference "braintree-ios-drop-in" */;
+			package = 428DB18E25F2C49E00B7EF7E /* XCRemoteSwiftPackageReference "braintree-ios-drop-in" */;
 			productName = BraintreeDropIn;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/Sources/BraintreeUIKit/Helpers/UIFont+BTUIK.m
+++ b/Sources/BraintreeUIKit/Helpers/UIFont+BTUIK.m
@@ -1,4 +1,8 @@
-#import "UIFont+BTUIK.h"
+#ifdef COCOAPODS
+#import <BraintreeDropIn/UIFont+BTUIK.h>
+#else
+#import <BraintreeUIKit/UIFont+BTUIK.h>
+#endif
 
 @implementation UIFont (BTUIK)
 


### PR DESCRIPTION

### Summary of changes

 - Add Build workflow to GitHub Actions to test that the SDK build for both CocoaPods and SPM. Punting on Carthage at the moment, since it needs more investigation.
 - Rename `testing.yml` --> `tests.yml` to match the base SDK. Update Xcode version and checkout action version.

 ### Checklist

 - ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens 
