### PR TITLE
Union pay dynamic fonts

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 binary "https://assets.braintreegateway.com/mobile/ios/carthage-frameworks/cardinal-mobile/CardinalMobile.json" "2.2.5"
 binary "https://assets.braintreegateway.com/mobile/ios/carthage-frameworks/pp-risk-magnes/PPRiskMagnes.json" "5.0.1"
-github "braintree/braintree_ios" "5.0.0"
+github "braintree/braintree_ios" "5.1.0"
 github "futuretap/InAppSettingsKit" "3.3"

--- a/Sources/BraintreeDropIn/Custom Views/BTEnrollmentVerificationViewController.m
+++ b/Sources/BraintreeDropIn/Custom Views/BTEnrollmentVerificationViewController.m
@@ -69,16 +69,12 @@
     self.resendSmsButton = [UIButton new];
     self.resendSmsButton.translatesAutoresizingMaskIntoConstraints = NO;
     [self.resendSmsButton setTitle:smsButtonText forState:UIControlStateNormal];
-    
-    NSAttributedString *normalValidateButtonString = [[NSAttributedString alloc] initWithString:smsButtonText
-                                                                                     attributes:@{NSForegroundColorAttributeName:[BTUIKAppearance sharedInstance].tintColor,
-                                                                                                  NSFontAttributeName:[BTUIKAppearance sharedInstance].bodyFont}];
-    [self.resendSmsButton setAttributedTitle:normalValidateButtonString forState:UIControlStateNormal];
-    NSAttributedString *disabledValidateButtonString = [[NSAttributedString alloc] initWithString:smsButtonText
-                                                                                       attributes:@{NSForegroundColorAttributeName:[BTUIKAppearance sharedInstance].disabledColor,
-                                                                                                    NSFontAttributeName:[BTUIKAppearance sharedInstance].bodyFont}];
-    [self.resendSmsButton setAttributedTitle:disabledValidateButtonString forState:UIControlStateDisabled];
-    
+
+    [self.resendSmsButton setTitleColor:[BTUIKAppearance sharedInstance].tintColor forState:UIControlStateNormal];
+    [self.resendSmsButton setTitleColor:[BTUIKAppearance sharedInstance].disabledColor forState:UIControlStateDisabled];
+
+    self.resendSmsButton.titleLabel.font = [BTUIKAppearance sharedInstance].staticHeadlineFont;
+
     [self.resendSmsButton sizeToFit];
     [self.resendSmsButton layoutIfNeeded];
     [self.resendSmsButton addTarget:self action:@selector(resendTapped) forControlEvents:UIControlEventTouchUpInside];

--- a/Sources/BraintreeDropIn/Custom Views/BTEnrollmentVerificationViewController.m
+++ b/Sources/BraintreeDropIn/Custom Views/BTEnrollmentVerificationViewController.m
@@ -44,14 +44,19 @@
     self.navigationItem.rightBarButtonItem.enabled = NO;
     self.edgesForExtendedLayout = UIRectEdgeNone;
     self.view.backgroundColor = [BTUIKAppearance sharedInstance].formBackgroundColor;
+
+    UIStackView *smsSentHeader = [BTDropInUIUtilities newStackView];
+    smsSentHeader.layoutMargins = UIEdgeInsetsMake(0, [BTUIKAppearance horizontalFormContentPadding], 0, [BTUIKAppearance horizontalFormContentPadding]);
+    smsSentHeader.layoutMarginsRelativeArrangement = YES;
+
     self.smsSentLabel = [UILabel new];
     self.smsSentLabel.translatesAutoresizingMaskIntoConstraints = NO;
     self.smsSentLabel.textAlignment = NSTextAlignmentCenter;
     NSString *fullMobileNumber = [NSString stringWithFormat:@"+%@ %@", self.mobileCountryCode, self.mobilePhoneNumber];
     self.smsSentLabel.text = [BTUIKLocalizedString insertIntoLocalizedString:BTUIKLocalizedString(ENTER_SMS_CODE_SENT_HELP_LABEL) replacement:fullMobileNumber];
     self.smsSentLabel.numberOfLines = 0;
-    [self.view addSubview:self.smsSentLabel];
     [BTUIKAppearance styleLargeLabelSecondary:self.smsSentLabel];
+    [smsSentHeader addArrangedSubview:self.smsSentLabel];
 
     self.smsTextField = [BTUIKFormField new];
     self.smsTextField.translatesAutoresizingMaskIntoConstraints = NO;
@@ -81,11 +86,11 @@
 
     self.stackView = [BTDropInUIUtilities newStackView];
 
-    [self.stackView addArrangedSubview:self.smsSentLabel];
+    [self.stackView addArrangedSubview:smsSentHeader];
     [self.stackView addArrangedSubview:self.smsTextField];
     [self.stackView addArrangedSubview:self.resendSmsButton];
 
-    [BTDropInUIUtilities addSpacerToStackView:self.stackView beforeView:self.smsSentLabel size:[BTUIKAppearance verticalFormSpace]];
+    [BTDropInUIUtilities addSpacerToStackView:self.stackView beforeView:smsSentHeader size:[BTUIKAppearance verticalFormSpace]];
     [BTDropInUIUtilities addSpacerToStackView:self.stackView beforeView:self.smsTextField size:[BTUIKAppearance verticalFormSpace]];
     [BTDropInUIUtilities addSpacerToStackView:self.stackView beforeView:self.resendSmsButton size:[BTUIKAppearance verticalFormSpaceTight]];
 
@@ -94,12 +99,7 @@
     self.smsErrorView = [BTDropInUIUtilities newStackViewForError:BTUIKLocalizedString(SMS_CODE_INVALID)];
     [self smsErrorHidden:YES];
 
-    NSDictionary* viewBindings = @{
-                                   @"smsSentLabel": self.smsSentLabel,
-                                   @"smsTextField": self.smsTextField,
-                                   @"resendSmsButton": self.resendSmsButton,
-                                   @"stackView": self.stackView,
-                                   };
+    NSDictionary* viewBindings = @{@"stackView": self.stackView};
 
     [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-[stackView]" options:0 metrics:[BTUIKAppearance metrics] views:viewBindings]];
     [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[stackView]|" options:0 metrics:[BTUIKAppearance metrics] views:viewBindings]];

--- a/Sources/BraintreeDropIn/Custom Views/BTEnrollmentVerificationViewController.m
+++ b/Sources/BraintreeDropIn/Custom Views/BTEnrollmentVerificationViewController.m
@@ -38,7 +38,6 @@
                                                                       NSForegroundColorAttributeName: [BTUIKAppearance sharedInstance].primaryTextColor
                                                                       }];
 
-    //self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancel)];
     BTUIKBarButtonItem *confirmButton = [[BTUIKBarButtonItem alloc] initWithTitle:BTUIKLocalizedString(CONFIRM_ACTION) style:UIBarButtonItemStyleDone target:self action:@selector(confirm)];
     confirmButton.bold = YES;
     self.navigationItem.rightBarButtonItem = confirmButton;
@@ -89,8 +88,6 @@
     [BTDropInUIUtilities addSpacerToStackView:self.stackView beforeView:self.smsSentLabel size:[BTUIKAppearance verticalFormSpace]];
     [BTDropInUIUtilities addSpacerToStackView:self.stackView beforeView:self.smsTextField size:[BTUIKAppearance verticalFormSpace]];
     [BTDropInUIUtilities addSpacerToStackView:self.stackView beforeView:self.resendSmsButton size:[BTUIKAppearance verticalFormSpaceTight]];
-
-    [self.smsTextField.heightAnchor constraintEqualToConstant:[BTUIKAppearance formCellHeight]].active = YES;
 
     [self.view addSubview:self.stackView];
 

--- a/Sources/BraintreeUIKit/Components/BTUIKFormField.m
+++ b/Sources/BraintreeUIKit/Components/BTUIKFormField.m
@@ -36,6 +36,7 @@
         self.textField.adjustsFontSizeToFitWidth = YES;
         self.textField.returnKeyType = UIReturnKeyNext;
         self.textField.keyboardAppearance = [BTUIKAppearance sharedInstance].keyboardAppearance;
+        self.textField.textAlignment = [BTUIKViewUtil naturalTextAlignment];
         [self.textField addTarget:self action:@selector(fieldContentDidChange) forControlEvents:UIControlEventEditingChanged];
         [self.textField addTarget:self action:@selector(editingDidBegin) forControlEvents:UIControlEventEditingDidBegin];
         [self.textField addTarget:self action:@selector(editingDidEnd) forControlEvents:UIControlEventEditingDidEnd];
@@ -68,10 +69,8 @@
 
         if (UIContentSizeCategoryIsAccessibilityCategory(self.traitCollection.preferredContentSizeCategory) && ![BTUIKAppearance sharedInstance].disableDynamicType) {
             self.stackView.axis = UILayoutConstraintAxisVertical;
-            self.textField.textAlignment = [BTUIKViewUtil naturalTextAlignment];
         } else {
             self.stackView.axis = UILayoutConstraintAxisHorizontal;
-            self.textField.textAlignment = [BTUIKViewUtil naturalTextAlignmentInverse];
         }
 
         [self.stackView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor].active = YES;


### PR DESCRIPTION
### Summary of changes

 - Update braintree_ios to version 5.1.0 in Cartfile.resolved. (The Cartfile itself specifies ~> 5.0.)
 - Allow text field on Union Pay SMS enrollment screen to scale vertically
 - Maintain horizontal padding around SMS sent label with larger fonts
 - Update "Use a different phone number button" to match the style of other buttons (i.e. bold and non-scaling)

 ### Checklist

 - ~Added a changelog entry~ (We already have an entry for dynamic type)

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens

### Screenshots

![Simulator Screen Shot - iPhone 12 - 2021-03-08 at 16 12 40](https://user-images.githubusercontent.com/51723734/110389384-125d0580-802a-11eb-9fa4-9f7044b881ba.png)

-------------------

![Simulator Screen Shot - iPhone 12 - 2021-03-08 at 16 13 14](https://user-images.githubusercontent.com/51723734/110389477-328cc480-802a-11eb-868c-6644f970b453.png)

---------------------

![Simulator Screen Shot - iPhone 12 - 2021-03-08 at 16 13 52](https://user-images.githubusercontent.com/51723734/110389484-34568800-802a-11eb-8324-0b7f3b77bc4e.png)

--------------

![Simulator Screen Shot - iPhone 12 - 2021-03-08 at 16 13 44](https://user-images.githubusercontent.com/51723734/110389482-33bdf180-802a-11eb-9913-6fc4abe51e6c.png)




