### PR TITLE
Fix crash on slow network connections

### DIFF
--- a/BraintreeDropIn/BTCardFormViewController.m
+++ b/BraintreeDropIn/BTCardFormViewController.m
@@ -143,7 +143,7 @@
     [self resetForm];
     [self showLoadingScreen:YES];
     [self loadConfiguration];
-    
+
     self.firstResponderFormField = self.cardNumberField;
 }
 
@@ -472,7 +472,7 @@
 
 - (void)advanceFocusFromField:(BTUIKFormField *)currentField {
     NSUInteger currentIdx = [self.requiredFields indexOfObject:currentField];
-    if (currentIdx < [self.requiredFields count] - 1) {
+    if (currentIdx != NSNotFound && currentIdx < self.requiredFields.count - 1) {
         [[self.requiredFields objectAtIndex:currentIdx + 1] becomeFirstResponder];
     }
 }
@@ -682,30 +682,32 @@
 #pragma mark FormField Delegate Methods
 
 - (void)validateButtonPressed:(__unused BTUIKFormField *)formField {
-    BTUIKCardType *cardType = self.cardNumberField.cardType;
-    BOOL cardSupported = NO;
-    for (id object in self.supportedCardTypes) {
-        BTUIKPaymentOptionType supportedCardType = ((NSNumber*)object).intValue;
-        if ( supportedCardType == [BTUIKViewUtil paymentMethodTypeForCardType:cardType]) {
-            cardSupported = YES;
-            break;
-        }
-    }
+    NSNumber *cardType = [NSNumber numberWithInt:[BTUIKViewUtil paymentMethodTypeForCardType:self.cardNumberField.cardType]];
+    BOOL cardSupported = [self.supportedCardTypes containsObject:cardType];
+
     if (!cardSupported) {
         [self cardNumberErrorHidden:NO errorString:BTUIKLocalizedString(CARD_NOT_ACCEPTED_ERROR_LABEL)];
         return;
     }
-    
-    if (!self.unionPayEnabledMerchant) {
-        [self cardNumberErrorHidden:formField.valid];
-        if (formField.valid) {
-            self.cardNumberField.state = BTUIKCardNumberFormFieldStateDefault;
-            self.collapsed = NO;
-            [self advanceFocusFromField:formField];
-        }
-    } else {
-        [self fetchCardCapabilities];
+
+    if (!formField.valid) {
+        [self cardNumberErrorHidden:NO];
+        return;
     }
+
+    if (!self.configuration) {
+        self.cardNumberField.state = BTUIKCardNumberFormFieldStateLoading;
+        return;
+    }
+
+    if (self.unionPayEnabledMerchant) {
+        [self fetchCardCapabilities];
+        return;
+    }
+
+    self.cardNumberField.state = BTUIKCardNumberFormFieldStateDefault;
+    self.collapsed = NO;
+    [self advanceFocusFromField:formField];
 }
 
 - (void)formFieldDidBeginEditing:(__unused BTUIKFormField *)formField {

--- a/BraintreeDropIn/BTDropInBaseViewController.m
+++ b/BraintreeDropIn/BTDropInBaseViewController.m
@@ -19,7 +19,7 @@
 - (instancetype)initWithAPIClient:(BTAPIClient *)apiClient request:(BTDropInRequest *)request
 {
     if (self = [super init]) {
-        self.apiClient = [apiClient copyWithSource:apiClient.metadata.source integration:BTClientMetadataIntegrationDropIn2];
+        self.apiClient = apiClient;
         _dropInRequest = request;
     }
     return self;

--- a/BraintreeDropIn/Public/BTCardFormViewController.h
+++ b/BraintreeDropIn/Public/BTCardFormViewController.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable, readonly) BTCardCapabilities *cardCapabilities;
 
 /// The card network types supported by this merchant
-@property (nonatomic, copy) NSArray *supportedCardTypes;
+@property (nonatomic, copy) NSArray<NSNumber *> *supportedCardTypes;
 
 /// Resets the state of the form fields
 - (void)resetForm;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree iOS Drop-in SDK - Release Notes
 
+## unreleased
+
+* Cards
+  * Fix crash on slow network connections fixes (#243)
+
 ## 8.1.3 (2021-03-02)
 
 * Fix localizations for Carthage integrations (fixes #272)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## unreleased
 
 * Cards
-  * Fix crash on slow network connections fixes (#243)
+  * Fix crash on slow network connections (fixes #243)
 
 ## 8.1.3 (2021-03-02)
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -25,16 +25,16 @@ PODS:
   - Braintree/Venmo (4.36.1):
     - Braintree/Core
     - Braintree/PayPalDataCollector
-  - BraintreeDropIn (8.1.2):
-    - BraintreeDropIn/DropIn (= 8.1.2)
-  - BraintreeDropIn/DropIn (8.1.2):
+  - BraintreeDropIn (8.1.3):
+    - BraintreeDropIn/DropIn (= 8.1.3)
+  - BraintreeDropIn/DropIn (8.1.3):
     - Braintree/Card (~> 4.32)
     - Braintree/Core (~> 4.32)
     - Braintree/PaymentFlow (~> 4.32)
     - Braintree/PayPal (~> 4.32)
     - Braintree/UnionPay (~> 4.32)
     - BraintreeDropIn/UIKit
-  - BraintreeDropIn/UIKit (8.1.2)
+  - BraintreeDropIn/UIKit (8.1.3)
   - Expecta (1.0.6)
   - InAppSettingsKit (3.1.2)
   - OCMock (3.6)
@@ -83,7 +83,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Braintree: f7e0e9a5030e22b8ad77e617f27ac9327d7bc004
-  BraintreeDropIn: 50b79151c55f2ffbfbbf9157c2d07d8e85479588
+  BraintreeDropIn: 92e960ee1e0a0ea3e722d494ff1e78699ca6c6b9
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   InAppSettingsKit: 988142fed825524ae44dd0d93684daf8f0358b8c
   OCMock: 5ea90566be239f179ba766fd9fbae5885040b992


### PR DESCRIPTION
### Summary of changes

- Resolve crash reported in #243 

The crash occurred after entering the card number if the configuration had not finished loading. Drop-in tried to auto-advance to the next field, but if the configuration hadn't finished loading, we didn't have the list of required fields yet, so there was nothing to advance to. The fix for this is to check if the index of the current field in the list of required fields is `NSNotFound`, and if so, skip the attempt to advance to the next field.

Additionally, we were copying `BTAPIClient` for each view controller that subclasses `BTDropInBaseViewController`. This meant that each view controller had to fetch the configuration, instead of using the cached configuration previously fetched. If we use the same instance of `BTAPIClient` across view controllers, we'll reduce latency by using the cached configuration and avoid any race conditions (like the one above).

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens
