### PR TITLE
Auto-scroll card number error view on screen

### DIFF
--- a/Sources/BraintreeDropIn/BTCardFormViewController.m
+++ b/Sources/BraintreeDropIn/BTCardFormViewController.m
@@ -509,13 +509,23 @@
 - (void)cardNumberErrorHidden:(BOOL)hidden errorString:(NSString *)errorString {
     NSInteger indexOfCardNumberFormField = [self.stackView.arrangedSubviews indexOfObject:self.cardNumberField];
     if (indexOfCardNumberFormField != NSNotFound && !hidden) {
-        [self.stackView insertArrangedSubview:self.cardNumberErrorView atIndex:indexOfCardNumberFormField + 1];
         UILabel *errorLabel = self.cardNumberErrorView.arrangedSubviews.firstObject;
         errorLabel.text = errorString;
         errorLabel.accessibilityLabel = errorString;
         errorLabel.accessibilityHint = BTUIKLocalizedString(REVIEW_AND_TRY_AGAIN);
-        UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification,
-                                        errorLabel);
+        [self.stackView insertArrangedSubview:self.cardNumberErrorView atIndex:indexOfCardNumberFormField + 1];
+        UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, errorLabel);
+        [self.view layoutIfNeeded];
+
+        // scroll so that error view is visible, if needed
+        CGFloat scrollViewBottom = self.scrollView.frame.size.height - self.scrollView.contentInset.bottom;
+        CGRect errorViewRect = [self.view convertRect:self.cardNumberErrorView.frame fromView:self.stackView];
+        CGFloat errorViewBottom = errorViewRect.origin.y + errorViewRect.size.height;
+        CGFloat diff = errorViewBottom - scrollViewBottom;
+
+        if (diff > 0) {
+            [self.scrollView setContentOffset:CGPointMake(0, self.scrollView.contentOffset.y + diff) animated:YES];
+        }
     } else if (self.cardNumberErrorView.superview != nil && hidden) {
         [self.cardNumberErrorView removeFromSuperview];
     }


### PR DESCRIPTION


### Summary of changes

 - If the user is using larger font sizes, the card number error view may be hidden by the keyboard. This PR adds logic to automatically scroll so that the error message is visible.

 ### Checklist

 - ~[] Added a changelog entry~ (I think we can consider this part of the dynamic fonts updates)

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens 
