### PR TITLE
Update Payment Method Icon Borders

### DIFF
--- a/Sources/BraintreeDropIn/Components/BTUIKCardListLabel.m
+++ b/Sources/BraintreeDropIn/Components/BTUIKCardListLabel.m
@@ -55,7 +55,8 @@
     NSMutableArray *attachments = [NSMutableArray new];
     BTUIKPaymentOptionCardView *hint = [BTUIKPaymentOptionCardView new];
     hint.frame = CGRectMake(0, 0, [BTUIKAppearance smallIconWidth], [BTUIKAppearance smallIconHeight]);
-
+    hint.borderColor = UIColor.systemGrayColor;
+    
     for (NSUInteger i = 0; i < self.availablePaymentOptions.count; i++) {
         NSTextAttachment *composeAttachment = [NSTextAttachment new];
         BTUIKPaymentOptionType paymentOption = ((NSNumber*)self.availablePaymentOptions[i]).intValue;

--- a/Sources/BraintreeDropIn/Components/BTUIKPaymentOptionCardView.m
+++ b/Sources/BraintreeDropIn/Components/BTUIKPaymentOptionCardView.m
@@ -16,8 +16,8 @@
         self.vectorArtSize = BTUIKVectorArtSizeRegular;
         self.cornerRadius = 4.0;
         self.innerPadding = 0.0;
-        self.borderWidth = 0.5;
-        self.borderColor = [BTUIKAppearance sharedInstance].lineColor;
+        self.borderWidth = 0.75;
+        self.borderColor = UIColor.blackColor;
         self.clipsToBounds = YES;
         self.backgroundColor = [UIColor whiteColor];
     }

--- a/Sources/BraintreeDropIn/Models/BTDropInResult.m
+++ b/Sources/BraintreeDropIn/Models/BTDropInResult.m
@@ -3,6 +3,7 @@
 #import "BTPaymentMethodNonce+DropIn.h"
 #import "BTUIKViewUtil.h"
 #import "BTUIKVectorArtView.h"
+#import "BTUIKPaymentOptionCardView.h"
 
 #ifdef COCOAPODS
 #import <Braintree/BraintreeCore.h>
@@ -38,7 +39,9 @@
 }
 
 - (UIView *)paymentIcon {
-    return [BTUIKViewUtil vectorArtViewForPaymentOptionType:self.paymentOptionType];
+    BTUIKPaymentOptionCardView *paymentOptionCardView = [BTUIKPaymentOptionCardView new];
+    paymentOptionCardView.paymentOptionType = self.paymentOptionType;
+    return paymentOptionCardView;
 }
 
 - (NSString *)paymentDescription {

--- a/Sources/BraintreeDropIn/Vector Art/BTUIKUnknownCardVectorArtView.m
+++ b/Sources/BraintreeDropIn/Vector Art/BTUIKUnknownCardVectorArtView.m
@@ -4,7 +4,7 @@
 
 - (void)drawArt {
     //// Color Declarations
-    UIColor* fillColor7 = [UIColor colorWithRed: 0.551 green: 0.551 blue: 0.551 alpha: 1];
+    UIColor* fillColor7 = UIColor.blackColor;
     
     //// Bezier Drawing
     UIBezierPath* bezierPath = [UIBezierPath bezierPath];


### PR DESCRIPTION
### Summary of changes

 - Update the icons in the payment method selection table view to use black borders. Since the Apple Pay mark requires a black border, this allows our other payment methods to match.
 - Update the `BTDropInResult.paymentIcon` to return the icon with a border.
 - Update the card icon to be black & white (instead of grey & white) to better stand out against Apple Pay.

 ### Checklist

 - [X] Added a changelog entry

### Authors
@scannillo @sestevens 
