### PR TITLE
Fix "Next" button UI bug on iOS 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * VoiceOver improvements
   * Fix color contrast ratios
   * Increase hit area for several buttons
+* Fix iOS 13 UI bug where "Next" button overlapped with card number text field
 
 ## 9.0.0-beta1 (2021-03-29)
 

--- a/Sources/BraintreeDropIn/BTCardFormViewController.m
+++ b/Sources/BraintreeDropIn/BTCardFormViewController.m
@@ -39,7 +39,6 @@
 @property (nonatomic, strong) UIStackView *cardNumberErrorView;
 @property (nonatomic, strong) UIStackView *cardNumberHeader;
 @property (nonatomic, strong) UIStackView *enrollmentFooter;
-@property (nonatomic, strong) UIButton *nextButton;
 @property (nonatomic, strong) NSArray <BTUIKFormField *> *formFields;
 @property (nonatomic, strong) NSMutableArray <BTUIKFormField *> *requiredFields;
 @property (nonatomic, strong) NSMutableArray <BTUIKFormField *> *optionalFields;
@@ -159,11 +158,6 @@
 #pragma mark - Setup
 
 - (void)setupForm {
-    self.nextButton = [[UIButton alloc] init];
-    [self.nextButton setTitle:BTUIKLocalizedString(NEXT_ACTION) forState:UIControlStateNormal];
-    self.nextButton.translatesAutoresizingMaskIntoConstraints = NO;
-    [self.nextButton setTitleColor:self.view.tintColor forState:UIControlStateNormal];
-    
     self.cardNumberField = [[BTUIKCardNumberFormField alloc] init];
     self.cardNumberField.delegate = self;
     self.cardNumberField.cardNumberDelegate = self;

--- a/Sources/BraintreeDropIn/Components/BTUIKFormField.m
+++ b/Sources/BraintreeDropIn/Components/BTUIKFormField.m
@@ -289,7 +289,6 @@
     _accessoryView = accessoryView;
     self.textField.rightView = self.accessoryView;
     self.textField.rightViewMode = UITextFieldViewModeAlways;
-    self.accessoryView.translatesAutoresizingMaskIntoConstraints = NO;
     [self.accessoryView setContentHuggingPriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
     [self.accessoryView setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
 }


### PR DESCRIPTION
### Summary of changes

 - Fix bug on iOS 13 where "Next" button on the Card entry form overlapped with the text field itself. 
 - Remove unused `NextButton` property

 ### Checklist

 - [X] Added a changelog entry

### Authors
@scannillo @sestevens 
