### PR TITLE
Clarify Swift 5.1+ requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Welcome to Braintree's Drop-In SDK for iOS!
 
 ![Drop-in light theme](Images/client-sdk-ios-series-light.png "Drop-in light theme")
 
-**The Braintree iOS Drop-In SDK requires Xcode 12+**. It permits a deployment target of iOS 12.0 or higher.
+**The Braintree iOS Drop-In SDK permits a deployment target of iOS 12.0 or higher.** It requires the use of Xcode 12+ and Swift 5.1+.
 
 <!--TODO: Update README for v9 major version changes -->
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Welcome to Braintree's Drop-In SDK for iOS!
 
 ![Drop-in light theme](Images/client-sdk-ios-series-light.png "Drop-in light theme")
 
-**The Braintree iOS Drop-In SDK permits a deployment target of iOS 12.0 or higher.** It requires the use of Xcode 12+ and Swift 5.1+.
+**The Braintree iOS Drop-In SDK permits a deployment target of iOS 12.0 or higher.** It requires Xcode 12+ and Swift 5.1+.
 
 <!--TODO: Update README for v9 major version changes -->
 

--- a/V9_MIGRATION.md
+++ b/V9_MIGRATION.md
@@ -16,7 +16,7 @@ _Documentation for v9 will be published to https://developers.braintreepayments.
 
 ## Supported Versions
 
-v9 supports a minimum deployment target of iOS 12+. It requires the use of Xcode 12+ and Swift 5+.
+v9 supports a minimum deployment target of iOS 12+. It requires the use of Xcode 12+ and Swift 5.1+.
 
 ## Swift Package Manager
 


### PR DESCRIPTION
### Summary of changes

 - Clarify Swift 5.1+ requirement. Swift 5 introduces ABI stability & 5.1 introduces module stability.


### Authors
@scannillo 