### PR TITLE
Fix Rakefile GH Release Step

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -197,10 +197,9 @@ namespace :publish do
     lines
   end
 
-  desc "Create GitHub release & attach .framework binaries."
+  desc "Create GitHub release"
   task :create_github_release do
-    run! "gh release create #{current_version} BraintreeDropIn.framework.zip -t #{current_version} -n '#{changelog_entries}'"
-    run! "rm -rf BraintreeDropIn.framework.zip"
+    run! "gh release create #{current_version} -t #{current_version} -n '#{changelog_entries}'"
   end
 end
 


### PR DESCRIPTION
### Summary of changes

 - Since Drop-In no longer supports Carthage, we don't need to include the `.framework` binaries in our GitHub release

 ### Checklist

 - ~Added a changelog entry~

### Authors
@scannillo 
