### PR TITLE
Minor UI Fixes

### DIFF
--- a/BraintreeDropIn.xcodeproj/project.pbxproj
+++ b/BraintreeDropIn.xcodeproj/project.pbxproj
@@ -62,9 +62,9 @@
 		42349088260BA5D30006D38B /* BTUIKAppearance.m in Sources */ = {isa = PBXBuildFile; fileRef = A52900E31D8903A600032220 /* BTUIKAppearance.m */; };
 		42349089260BA5D30006D38B /* BTUIKViewUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = A52900E41D8903A600032220 /* BTUIKViewUtil.m */; };
 		4234908A260BA5D30006D38B /* UIColor+BTUIK.m in Sources */ = {isa = PBXBuildFile; fileRef = A52900E51D8903A600032220 /* UIColor+BTUIK.m */; };
-		423490A1260BA64C0006D38B /* BTDropInPaymentMethodType.h in Headers */ = {isa = PBXBuildFile; fileRef = A52901131D8903A600032220 /* BTDropInPaymentMethodType.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		42349091260BA5EF0006D38B /* BTDropInLocalization.m in Sources */ = {isa = PBXBuildFile; fileRef = A52900E71D8903A600032220 /* BTDropInLocalization.m */; };
 		42349098260BA6000006D38B /* BTDropInLocalization.h in Headers */ = {isa = PBXBuildFile; fileRef = A529010F1D8903A600032220 /* BTDropInLocalization.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		423490A1260BA64C0006D38B /* BTDropInPaymentMethodType.h in Headers */ = {isa = PBXBuildFile; fileRef = A52901131D8903A600032220 /* BTDropInPaymentMethodType.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		423490B8260BA7680006D38B /* BTUIKVisualAssetType.h in Headers */ = {isa = PBXBuildFile; fileRef = 03AE59571DDE7E8C000B594C /* BTUIKVisualAssetType.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4237D7A425E42844006F6CE3 /* BTDropInUICustomization.h in Headers */ = {isa = PBXBuildFile; fileRef = 4237D7A225E42844006F6CE3 /* BTDropInUICustomization.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4237D7A525E42844006F6CE3 /* BTDropInUICustomization.m in Sources */ = {isa = PBXBuildFile; fileRef = 4237D7A325E42844006F6CE3 /* BTDropInUICustomization.m */; };
@@ -889,10 +889,9 @@
 			};
 			buildConfigurationList = A56C41641D833348000DFFAB /* Build configuration list for PBXProject "BraintreeDropIn" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 				Base,
 				en_AU,

--- a/Demo/UITests/Helpers.swift
+++ b/Demo/UITests/Helpers.swift
@@ -10,7 +10,12 @@ extension XCTestCase {
         waitForExpectations(timeout: timeout) { (error) -> Void in
             if (error != nil) {
                 let message = "Failed to find \(element) after \(timeout) seconds."
-                self.recordFailure(withDescription: message, inFile: file, atLine: line, expected: true)
+                self.record(XCTIssue(type: .assertionFailure,
+                                     compactDescription: message,
+                                     detailedDescription: nil,
+                                     sourceCodeContext: XCTSourceCodeContext(location: XCTSourceCodeLocation(filePath: file, lineNumber: Int(line))),
+                                     associatedError: error,
+                                     attachments: []))
             }
         }
     }
@@ -24,7 +29,12 @@ extension XCTestCase {
         waitForExpectations(timeout: timeout) { (error) -> Void in
             if (error != nil) {
                 let message = "Failed to find \(element) after \(timeout) seconds."
-                self.recordFailure(withDescription: message, inFile: file, atLine: line, expected: true)
+                self.record(XCTIssue(type: .assertionFailure,
+                                     compactDescription: message,
+                                     detailedDescription: nil,
+                                     sourceCodeContext: XCTSourceCodeContext(location: XCTSourceCodeLocation(filePath: file, lineNumber: Int(line))),
+                                     associatedError: error,
+                                     attachments: []))
             }
         }
     }

--- a/Sources/BraintreeDropIn/Custom Views/BTDropInPaymentSelectionCell.m
+++ b/Sources/BraintreeDropIn/Custom Views/BTDropInPaymentSelectionCell.m
@@ -27,6 +27,7 @@
 
         self.label = [[UILabel alloc] init];
         [BTUIKAppearance styleLabelPrimary:self.label];
+        self.label.numberOfLines = 2;
         self.label.translatesAutoresizingMaskIntoConstraints = NO;
         [self.labelContainer addArrangedSubview:self.label];
 

--- a/Sources/BraintreeDropIn/Custom Views/BTPaymentSelectionHeaderView.m
+++ b/Sources/BraintreeDropIn/Custom Views/BTPaymentSelectionHeaderView.m
@@ -40,7 +40,7 @@
         [self.button.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor constant:-[BTUIKAppearance horizontalFormContentPadding]].active = YES;
         [self.button.topAnchor constraintEqualToAnchor:self.contentView.topAnchor].active = YES;
         [self.button.bottomAnchor constraintEqualToAnchor:self.contentView.bottomAnchor].active = YES;
-        [self.button.widthAnchor constraintEqualToConstant:BTUIKAppearance.minimumHitArea].active = YES;
+        [self.button.widthAnchor constraintGreaterThanOrEqualToConstant:BTUIKAppearance.minimumHitArea].active = YES;
     }
     return self;
 }


### PR DESCRIPTION


### Summary of changes

UI updates:
 - Allow payment method text (e.g., "Credit or debit card") to wrap to 2 lines
 - Fix truncation of "Edit" button in languages where the text is longer (e.g. German)

Deprecation warning fixes:
 - Fix deprecation warning for "English" as the development region instead of "en"
 - Update deprecated methods in UI test target

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens 

### Screenshots

#### "Credit or debit card" truncating
| Before | After |
|------------|---------|
| ![Simulator Screen Shot - iPhone 11 - 2021-04-05 at 15 34 22](https://user-images.githubusercontent.com/51723734/113625496-9ead1900-9626-11eb-99cd-6b098f4c16da.png) | ![Simulator Screen Shot - iPhone 11 - 2021-04-05 at 15 34 03](https://user-images.githubusercontent.com/51723734/113625550-abca0800-9626-11eb-8bec-83a4df6e1ba3.png) |

#### Edit button truncating
| Before | After |
|------------|---------|
| ![Simulator Screen Shot - iPhone 11 - 2021-04-05 at 15 39 58](https://user-images.githubusercontent.com/51723734/113625779-f9467500-9626-11eb-951b-a59cd3b57f84.png) | ![Simulator Screen Shot - iPhone 11 - 2021-04-05 at 15 40 18](https://user-images.githubusercontent.com/51723734/113625798-ffd4ec80-9626-11eb-9a32-2aa7295dd046.png) |

