### PR TITLE
Apple Pay - Guideline Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
     * Fix bug where fetching most recent payment methods would return an empty `BTDropInResult` instead of `nil` when the customer doesn't have any vaulted payment methods
     * Rename `BTUIKPaymentOptionType` enum to `BTDropInPaymentMethodType`
     * Rename `paymentOptionType` property to `paymentMethodType`
+  * Apple Pay
+    * Always show Apple Pay payment method option if device is capable of Apple Pay (fixes #232)
 
 ## 9.0.0-beta1 (2021-03-29)
 

--- a/README.md
+++ b/README.md
@@ -85,13 +85,7 @@ func showDropIn(clientTokenOrTokenizationKey: String) {
 
 ### Apple Pay + Drop-In
 
-Apple Pay is enabled by default in Drop-In. Unless you opt out, by setting `applePayDisabled = true`, Drop-In will show Apple Pay as a payment option as long as it is enabled in the control panel. Below is an example of hiding the Apple Pay button if the device can't make Apple Pay payments using certain card networks:
-
-```swift
-let request =  BTDropInRequest()
-let canMakePayments = PKPaymentAuthorizationViewController.canMakePayments() && PKPaymentAuthorizationViewController.canMakePayments(usingNetworks: [.amex, .visa, .masterCard])
-request.applePayDisabled = !canMakePayments
-```
+Apple Pay is enabled by default in Drop-In. Drop-In will show Apple Pay as a payment option as long as it is enabled in the control panel and the device supports it. To opt out, set `applePayDisabled = true` on your `BTDropInRequest`.
 
 **Important:** If your customer selects Apple Pay as their preferred payment method then `result.paymentMethodType == .applePay` and the `result.paymentMethod` will be `nil`. Selecting Apple Pay does not display the Apple Pay sheet or create a nonce. After you receive the `BTDropInResult`, you will need to:
 1) Display a `PKPaymentButton`.

--- a/Sources/BraintreeDropIn/BTPaymentSelectionViewController.m
+++ b/Sources/BraintreeDropIn/BTPaymentSelectionViewController.m
@@ -131,7 +131,7 @@ static BOOL _vaultedCardAppearAnalyticSent = NO;
                 }
             }
 
-            if (self.configuration.isApplePayEnabled && !self.dropInRequest.applePayDisabled && self.configuration.canMakeApplePayPayments) {
+            if (self.configuration.isApplePayEnabled && !self.dropInRequest.applePayDisabled && [PKPaymentAuthorizationController canMakePayments]) {
                 [activePaymentOptions addObject:@(BTDropInPaymentMethodTypeApplePay)];
             }
 


### PR DESCRIPTION
### Summary of changes

 - [GH Issue ](https://github.com/braintree/braintree-ios-drop-in/issues/232)
 - [Apple Pay's Guidelines](https://developer.apple.com/design/human-interface-guidelines/apple-pay/overview/offering-apple-pay/) require the Apple Pay button be shown whenever the device supports Apple Pay
     - Previously we used `canMakePaymentsUsingNetworks` to show the Apple Pay option if the customer's device had an Apple Pay wallet already set up
     - This PR updates to use `canMakePayments` to show the Apple Pay option if the device is capable of checking out with Apple Pay 

 ### Checklist

 - [X] Added a changelog entry

### Authors
@scannillo @sestevens 
