### PR TITLE
Fix payment selection sheet height bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   * Add validation to cardholder name field to prevent users from accidentally inputting credit card numbers
 * Payment selection sheet
   * Fix bug where vaulted payment methods were shown even when the payment method was disabled on `BTDropInRequest` (fixes #179)
+  * Fix bug where top of payment selection sheet was cut off on smaller phones using larger fonts
 * Breaking changes
   * Localization
     * Rename `BTUIKLocalizedString` to `BTDropInLocalization`

--- a/Sources/BraintreeDropIn/BTDropInController.m
+++ b/Sources/BraintreeDropIn/BTDropInController.m
@@ -442,12 +442,14 @@
 }
 
 - (void)sheetHeightDidChange:(__unused BTPaymentSelectionViewController *)sender {
-    self.contentViewTopConstraint.constant = [self calculateContentViewTopConstraintConstant];
-    self.contentViewBottomConstraint.constant = -[self sheetInset];
+    if (!self.isBeingDismissed) {
+        self.contentViewTopConstraint.constant = [self calculateContentViewTopConstraintConstant];
+        self.contentViewBottomConstraint.constant = -[self sheetInset];
 
-    [UIView animateWithDuration:BT_ANIMATION_TRANSITION_SPEED delay:0.0 usingSpringWithDamping:0.8 initialSpringVelocity:4 options:0 animations:^{
-        [self.view layoutIfNeeded];
-    } completion:nil];
+        [UIView animateWithDuration:BT_ANIMATION_TRANSITION_SPEED delay:0.0 usingSpringWithDamping:0.8 initialSpringVelocity:4 options:0 animations:^{
+            [self.view layoutIfNeeded];
+        } completion:nil];
+    }
 }
 
 #pragma mark BTDropInControllerDelegate

--- a/Sources/BraintreeDropIn/BTDropInController.m
+++ b/Sources/BraintreeDropIn/BTDropInController.m
@@ -355,10 +355,6 @@
     self.paymentSelectionNavigationController.view.alpha = 1.0;
 }
 
-- (BOOL)isFullScreen {
-    return ![self supportsHalfSheet] || [self isFormSheet] ;
-}
-
 // No half sheet when in landscape or FormSheet modes.
 - (BOOL)supportsHalfSheet {
     if([BTUIKViewUtil isOrientationLandscape] || [self isFormSheet]) {
@@ -378,10 +374,9 @@
 - (CGFloat)calculateContentViewTopConstraintConstant {
     if ([self isFormSheet]) {
         return 0;
-    } else if (self.isFullScreen) {
-        return [BTUIKViewUtil statusBarHeight] + [self sheetInset];
     } else {
-        return [self safeAreaHeight] - [self.paymentSelectionViewController sheetHeight] - [self sheetInset];
+        CGFloat topOffset = [self safeAreaHeight] - [self.paymentSelectionViewController sheetHeight] - [self sheetInset];
+        return MAX(BT_HALF_SHEET_MARGIN, topOffset);
     }
 }
 

--- a/Sources/BraintreeDropIn/BTPaymentSelectionViewController.m
+++ b/Sources/BraintreeDropIn/BTPaymentSelectionViewController.m
@@ -78,6 +78,7 @@ static BOOL _vaultedCardAppearAnalyticSent = NO;
 
     self.paymentOptionsTableView = [[UITableView alloc] initWithFrame:CGRectZero style:UITableViewStyleGrouped];
     self.paymentOptionsTableView.backgroundColor = UIColor.clearColor;
+    [self.paymentOptionsTableView addObserver:self forKeyPath:@"contentSize" options:0 context:NULL];
     [self.paymentOptionsTableView registerClass:BTDropInPaymentSelectionCell.class forCellReuseIdentifier:@"BTDropInPaymentSelectionCell"];
     [self.paymentOptionsTableView registerClass:BTVaultedPaymentMethodsTableViewCell.class forCellReuseIdentifier:@"BTVaultedPaymentMethodsTableViewCell"];
     [self.paymentOptionsTableView registerClass:BTPaymentSelectionHeaderView.class forHeaderFooterViewReuseIdentifier:@"BTPaymentSelectionHeaderView"];
@@ -94,6 +95,18 @@ static BOOL _vaultedCardAppearAnalyticSent = NO;
         [self.paymentOptionsTableView.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor],
         [self.paymentOptionsTableView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor]
     ]];
+}
+
+- (void)dealloc {
+    [self.paymentOptionsTableView removeObserver:self forKeyPath:@"contentSize"];
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary <NSString *, id> *)change context:(void *)context {
+    if ([keyPath isEqualToString:@"contentSize"]) {
+        [self.delegate sheetHeightDidChange:self];
+    } else {
+        [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+    }
 }
 
 - (void)loadConfiguration {
@@ -141,10 +154,6 @@ static BOOL _vaultedCardAppearAnalyticSent = NO;
                 [self sendVaultedCardAppearAnalytic];
             }
             [self showLoadingScreen:NO];
-            [self.view layoutIfNeeded];
-            if (self.delegate) {
-                [self.delegate sheetHeightDidChange:self];
-            }
         }];
     }
 }


### PR DESCRIPTION


### Summary of changes

Fix 2 bugs related to the height of the payment selection sheet:
 - On smaller screens (such as iPhone SE) with large fonts enabled, the "Cancel" button and header on the payment selection sheet were pushed above the top of the screen, so the user wasn't able to cancel out of drop-in.
 - The initial height of the payment selection screen was too short. This was especially noticeable with larger fonts, because some of the payment options were cut off. Opening and closing the card form made the payment selection screen jump to the correct height.

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens 
- @scannillo 

### Screenshots

#### Cancel button cut off bug

| Before | After |
|--------|----------|
| ![Simulator Screen Shot - iPhone SE (2nd generation) - 2021-04-06 at 16 42 40](https://user-images.githubusercontent.com/51723734/113932407-2e82cc80-97b9-11eb-9705-d2bfccd05158.png) | ![Simulator Screen Shot - iPhone SE (2nd generation) - 2021-04-07 at 15 50 58](https://user-images.githubusercontent.com/51723734/113932434-36427100-97b9-11eb-8981-fed719285b8d.png) |


