### PR TITLE
Add SwiftUI demo to demo app

### DIFF
--- a/Demo.xcodeproj/project.pbxproj
+++ b/Demo.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		4221CD56260E66D30025F6AD /* DemoPurchaseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4221CD55260E66D30025F6AD /* DemoPurchaseButton.swift */; };
+		4226FBB32620A61F006F45FE /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4226FBB22620A61F006F45FE /* ContentView.swift */; };
+		4226FBB82620A765006F45FE /* DropInRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4226FBB72620A765006F45FE /* DropInRepresentable.swift */; };
 		422B6327260E4D3C00CAE202 /* Main.strings in Resources */ = {isa = PBXBuildFile; fileRef = 422B62EE260E4D3C00CAE202 /* Main.strings */; };
 		422B6328260E4D3C00CAE202 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 422B62F0260E4D3C00CAE202 /* InfoPlist.strings */; };
 		422B6329260E4D3C00CAE202 /* BTUI.strings in Resources */ = {isa = PBXBuildFile; fileRef = 422B630D260E4D3C00CAE202 /* BTUI.strings */; };
@@ -58,6 +60,8 @@
 /* Begin PBXFileReference section */
 		421F783C260E37EE003F99B5 /* braintree-ios-drop-in */ = {isa = PBXFileReference; lastKnownFileType = text; name = "braintree-ios-drop-in"; path = .; sourceTree = SOURCE_ROOT; };
 		4221CD55260E66D30025F6AD /* DemoPurchaseButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoPurchaseButton.swift; sourceTree = "<group>"; };
+		4226FBB22620A61F006F45FE /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		4226FBB72620A765006F45FE /* DropInRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropInRepresentable.swift; sourceTree = "<group>"; };
 		422B62EF260E4D3C00CAE202 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Main.strings; sourceTree = "<group>"; };
 		422B62F1260E4D3C00CAE202 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		422B62F2260E4D3C00CAE202 /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/Main.strings; sourceTree = "<group>"; };
@@ -171,6 +175,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		4226FBA62620A2E3006F45FE /* SwiftUI */ = {
+			isa = PBXGroup;
+			children = (
+				4226FBB22620A61F006F45FE /* ContentView.swift */,
+				4226FBB72620A765006F45FE /* DropInRepresentable.swift */,
+			);
+			path = SwiftUI;
+			sourceTree = "<group>";
+		};
 		422B62ED260E4D3C00CAE202 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
@@ -219,6 +232,7 @@
 		4245D864256C5C4E00F1A413 /* Application */ = {
 			isa = PBXGroup;
 			children = (
+				4226FBA62620A2E3006F45FE /* SwiftUI */,
 				422B6330260E4D5700CAE202 /* Assets.xcassets */,
 				4245D868256C5C4E00F1A413 /* DemoAppDelegate.swift */,
 				4245D86A256C5C4E00F1A413 /* DemoBaseViewController.swift */,
@@ -454,9 +468,11 @@
 				4221CD56260E66D30025F6AD /* DemoPurchaseButton.swift in Sources */,
 				4245D884256C5C4E00F1A413 /* ViewHelpers.swift in Sources */,
 				4245D88C256C5C4F00F1A413 /* DemoDropInView.swift in Sources */,
+				4226FBB32620A61F006F45FE /* ContentView.swift in Sources */,
 				4245D881256C5C4E00F1A413 /* DemoAppDelegate.swift in Sources */,
 				4245D88D256C5C4F00F1A413 /* DemoMerchantAPIClient.swift in Sources */,
 				4245D885256C5C4E00F1A413 /* DemoDropInViewController.swift in Sources */,
+				4226FBB82620A765006F45FE /* DropInRepresentable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Demo/Application/Settings/DemoSettings.swift
+++ b/Demo/Application/Settings/DemoSettings.swift
@@ -1,5 +1,10 @@
 import BraintreeDropIn
 
+enum DemoUIFramework: Int {
+    case uikit
+    case swiftui
+}
+
 enum DemoEnvironment: Int {
     case sandbox
     case production
@@ -13,12 +18,17 @@ enum DemoThreeDSecureRequiredSetting: Int {
 }
 
 class DemoSettings {
-    
+
+    static let UIFrameworkDefaultsKey = "BraintreeDemoSettingsUIFrameworkDefaultsKey"
     static let EnvironmentDefaultsKey = "BraintreeDemoSettingsEnvironmentDefaultsKey"
     static let CustomEnvironmentURLDefaultsKey = "BraintreeDemoSettingsCustomEnvironmentURLDefaultsKey"
     static let ThreeDSecureRequiredDefaultsKey = "BraintreeDemoSettingsThreeDSecureRequiredDefaultsKey"
     static let ThreeDSecureVersionDefaultsKey = "BraintreeDemoSettingsThreeDSecureVersionDefaultsKey"
-    
+
+    static var currentUIFramework: DemoUIFramework {
+        return DemoUIFramework(rawValue: UserDefaults.standard.integer(forKey: UIFrameworkDefaultsKey)) ?? DemoUIFramework.uikit
+    }
+
     static var currentEnvironment: DemoEnvironment {
         return DemoEnvironment(rawValue: UserDefaults.standard.integer(forKey: EnvironmentDefaultsKey)) ?? DemoEnvironment.sandbox
     }

--- a/Demo/Application/Settings/Settings.bundle/Root.plist
+++ b/Demo/Application/Settings/Settings.bundle/Root.plist
@@ -8,6 +8,26 @@
 			<key>Type</key>
 			<string>PSMultiValueSpecifier</string>
 			<key>Title</key>
+			<string>UI Framework</string>
+			<key>Key</key>
+			<string>BraintreeDemoSettingsUIFrameworkDefaultsKey</string>
+			<key>DefaultValue</key>
+			<string>0</string>
+			<key>Titles</key>
+			<array>
+				<string>UIKit</string>
+				<string>SwiftUI</string>
+			</array>
+			<key>Values</key>
+			<array>
+				<string>0</string>
+				<string>1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSMultiValueSpecifier</string>
+			<key>Title</key>
 			<string>Environment</string>
 			<key>Key</key>
 			<string>BraintreeDemoSettingsEnvironmentDefaultsKey</string>

--- a/Demo/Application/SwiftUI/ContentView.swift
+++ b/Demo/Application/SwiftUI/ContentView.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+@available(iOS 13, *)
+struct ContentView: View {
+    let tokenizationKey = "sandbox_9dbg82cq_dcpspy2brwdjr3qn"
+
+    @State var showDropIn = false
+
+    var body: some View {
+        ZStack {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("CART")
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal, 20)
+                    .padding(.top, 20)
+                HStack {
+                    Text("1 Sock")
+                    Spacer()
+                    Text("$10")
+                }
+                .padding(.horizontal, 20)
+                Button(action: { self.showDropIn = true }) {
+                    HStack {
+                        Spacer()
+                        Text("Select Payment Method")
+                            .fontWeight(.bold)
+                            .font(.body)
+                        Spacer()
+                    }
+                    .padding(.vertical, 12)
+                    .foregroundColor(.white)
+                    .background(Color.blue)
+                }
+                .padding(.top, 40)
+                .padding(.horizontal, 20)
+                Spacer()
+            }.edgesIgnoringSafeArea(.vertical)
+
+            if self.showDropIn {
+                DropInRepresentable(authorization: tokenizationKey, handler: { controller, result, error in
+                    self.showDropIn = false
+                }).edgesIgnoringSafeArea(.vertical)
+            }
+        }
+    }
+}
+
+@available(iOS 13, *)
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/Demo/Application/SwiftUI/DropInRepresentable.swift
+++ b/Demo/Application/SwiftUI/DropInRepresentable.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+import BraintreeDropIn
+
+@available(iOS 13, *)
+struct DropInRepresentable: UIViewControllerRepresentable {
+    var authorization: String
+    var handler: BTDropInControllerHandler
+
+    init(authorization: String, handler: @escaping BTDropInControllerHandler) {
+        self.authorization = authorization
+        self.handler = handler
+    }
+
+    func makeUIViewController(context: Context) -> BTDropInController {
+        let request = BTDropInRequest()
+        request.payPalRequest = BTPayPalCheckoutRequest(amount: "10.00")
+        return BTDropInController(authorization: authorization, request: request, handler: handler)!
+    }
+
+    func updateUIViewController(_ uiViewController: BTDropInController, context: UIViewControllerRepresentableContext<DropInRepresentable>) {
+
+    }
+}

--- a/README.md
+++ b/README.md
@@ -212,6 +212,10 @@ dropInRequest.uiCustomization = uiCustomization
 
 Drop-in UI elements support VoiceOver.
 
+#### SwiftUI
+
+Drop-in does not officially support SwiftUI at this time.
+
 ### More Information
 
 Start with [**'Hello, Client!'**](https://developers.braintreepayments.com/ios/start/hello-client) for instructions on basic setup and usage.


### PR DESCRIPTION

### Summary of changes

 - Add SwiftUI demo to the demo app. You can access it selecting "SwiftUI" from the "UI Frameworks" option in the Settings page.

This PR doesn't fix any issues with SwiftUI, and it's not really a fully fleshed out example of how to integrate with Drop-in using SwiftUI. My thought is just that it'll help us to reproduce SwiftUI issues as they come in and give us a better view into how Drop-in works (or doesn't) with SwiftUI.

If we want, we could even add a disclaimer to the README about how we don't officially support SwiftUI at this point. That way, we can be clear that the existence of this demo doesn't actually mean official SwiftUI support.

 ### Checklist

 - ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens 
