### PR TITLE
Fix issue with mixed SPM/CocoaPods projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * VoiceOver improvements
   * Add localized helper text for image of available card types on card entry form
+* Swift Package Manager
+  * Fix issue with mixed SPM/CocoaPods projects (fixes #325)
 
 ## 9.0.0 (2021-04-08)
 

--- a/Sources/BraintreeDropIn/BTAPIClient_Internal_Category.h
+++ b/Sources/BraintreeDropIn/BTAPIClient_Internal_Category.h
@@ -1,4 +1,4 @@
-#ifdef COCOAPODS
+#if __has_include(<BraintreeDropIn/BraintreeDropIn.h>) // CocoaPods
 #import <Braintree/BraintreeCore.h>
 #else
 #import <BraintreeCore/BraintreeCore.h>

--- a/Sources/BraintreeDropIn/BTAPIClient_Internal_Category.h
+++ b/Sources/BraintreeDropIn/BTAPIClient_Internal_Category.h
@@ -1,4 +1,4 @@
-#if __has_include(<BraintreeDropIn/BraintreeDropIn.h>) // CocoaPods
+#if __has_include(<Braintree/BraintreeCore.h>) // CocoaPods
 #import <Braintree/BraintreeCore.h>
 #else
 #import <BraintreeCore/BraintreeCore.h>

--- a/Sources/BraintreeDropIn/BTCardFormViewController.m
+++ b/Sources/BraintreeDropIn/BTCardFormViewController.m
@@ -12,7 +12,7 @@
 #import "BTUIKViewUtil.h"
 #import "BTDropInLocalization_Internal.h"
 
-#if __has_include(<BraintreeDropIn/BraintreeDropIn.h>) // CocoaPods
+#if __has_include(<Braintree/BraintreeCore.h>) // CocoaPods
 #import <Braintree/BraintreeCard.h>
 #import <Braintree/BraintreeCore.h>
 #import <Braintree/BraintreePaymentFlow.h>

--- a/Sources/BraintreeDropIn/BTCardFormViewController.m
+++ b/Sources/BraintreeDropIn/BTCardFormViewController.m
@@ -12,7 +12,7 @@
 #import "BTUIKViewUtil.h"
 #import "BTDropInLocalization_Internal.h"
 
-#ifdef COCOAPODS
+#if __has_include(<BraintreeDropIn/BraintreeDropIn.h>) // CocoaPods
 #import <Braintree/BraintreeCard.h>
 #import <Braintree/BraintreeCore.h>
 #import <Braintree/BraintreePaymentFlow.h>

--- a/Sources/BraintreeDropIn/BTDropInController.m
+++ b/Sources/BraintreeDropIn/BTDropInController.m
@@ -8,7 +8,7 @@
 #import "BTUIKViewUtil.h"
 #import "BTConfiguration+DropIn.h"
 
-#ifdef COCOAPODS
+#if __has_include(<BraintreeDropIn/BraintreeDropIn.h>) // CocoaPods
 #import <Braintree/BraintreeCard.h>
 #import <Braintree/BraintreeCore.h>
 #import <Braintree/BraintreePaymentFlow.h>

--- a/Sources/BraintreeDropIn/BTDropInController.m
+++ b/Sources/BraintreeDropIn/BTDropInController.m
@@ -8,7 +8,7 @@
 #import "BTUIKViewUtil.h"
 #import "BTConfiguration+DropIn.h"
 
-#if __has_include(<BraintreeDropIn/BraintreeDropIn.h>) // CocoaPods
+#if __has_include(<Braintree/BraintreeCore.h>) // CocoaPods
 #import <Braintree/BraintreeCard.h>
 #import <Braintree/BraintreeCore.h>
 #import <Braintree/BraintreePaymentFlow.h>

--- a/Sources/BraintreeDropIn/BTPaymentMethodNonce+DropIn.h
+++ b/Sources/BraintreeDropIn/BTPaymentMethodNonce+DropIn.h
@@ -1,7 +1,7 @@
 #import <BraintreeDropIn/BTDropInRequest.h>
 #import "BTConfiguration+DropIn.h"
 
-#if __has_include(<BraintreeDropIn/BraintreeDropIn.h>) // CocoaPods
+#if __has_include(<Braintree/BraintreeCore.h>) // CocoaPods
 #import <Braintree/BraintreeCore.h>
 #else
 #import <BraintreeCore/BraintreeCore.h>

--- a/Sources/BraintreeDropIn/BTPaymentMethodNonce+DropIn.h
+++ b/Sources/BraintreeDropIn/BTPaymentMethodNonce+DropIn.h
@@ -1,7 +1,7 @@
 #import <BraintreeDropIn/BTDropInRequest.h>
 #import "BTConfiguration+DropIn.h"
 
-#ifdef COCOAPODS
+#if __has_include(<BraintreeDropIn/BraintreeDropIn.h>) // CocoaPods
 #import <Braintree/BraintreeCore.h>
 #else
 #import <BraintreeCore/BraintreeCore.h>

--- a/Sources/BraintreeDropIn/BTPaymentMethodNonce+DropIn.m
+++ b/Sources/BraintreeDropIn/BTPaymentMethodNonce+DropIn.m
@@ -1,6 +1,6 @@
 #import "BTPaymentMethodNonce+DropIn.h"
 
-#if __has_include(<BraintreeDropIn/BraintreeDropIn.h>) // CocoaPods
+#if __has_include(<Braintree/BraintreeCore.h>) // CocoaPods
 #import <Braintree/BTCardNonce.h>
 #import <Braintree/BTPayPalAccountNonce.h>
 #import <Braintree/BTConfiguration+PayPal.h>

--- a/Sources/BraintreeDropIn/BTPaymentMethodNonce+DropIn.m
+++ b/Sources/BraintreeDropIn/BTPaymentMethodNonce+DropIn.m
@@ -1,6 +1,6 @@
 #import "BTPaymentMethodNonce+DropIn.h"
 
-#ifdef COCOAPODS
+#if __has_include(<BraintreeDropIn/BraintreeDropIn.h>) // CocoaPods
 #import <Braintree/BTCardNonce.h>
 #import <Braintree/BTPayPalAccountNonce.h>
 #import <Braintree/BTConfiguration+PayPal.h>

--- a/Sources/BraintreeDropIn/BTPaymentSelectionViewController.h
+++ b/Sources/BraintreeDropIn/BTPaymentSelectionViewController.h
@@ -2,7 +2,7 @@
 #import "BTDropInBaseViewController.h"
 #import <BraintreeDropIn/BTDropInPaymentMethodType.h>
 
-#if __has_include(<BraintreeDropIn/BraintreeDropIn.h>) // CocoaPods
+#if __has_include(<Braintree/BraintreeCore.h>) // CocoaPods
 #import <Braintree/BTVenmoDriver.h>
 #else
 #import <BraintreeVenmo/BTVenmoDriver.h>

--- a/Sources/BraintreeDropIn/BTPaymentSelectionViewController.h
+++ b/Sources/BraintreeDropIn/BTPaymentSelectionViewController.h
@@ -2,7 +2,7 @@
 #import "BTDropInBaseViewController.h"
 #import <BraintreeDropIn/BTDropInPaymentMethodType.h>
 
-#ifdef COCOAPODS
+#if __has_include(<BraintreeDropIn/BraintreeDropIn.h>) // CocoaPods
 #import <Braintree/BTVenmoDriver.h>
 #else
 #import <BraintreeVenmo/BTVenmoDriver.h>

--- a/Sources/BraintreeDropIn/BTPaymentSelectionViewController.m
+++ b/Sources/BraintreeDropIn/BTPaymentSelectionViewController.m
@@ -10,7 +10,7 @@
 #import "BTConfiguration+DropIn.h"
 #import "BTPaymentMethodNonce+DropIn.h"
 
-#if __has_include(<BraintreeDropIn/BraintreeDropIn.h>) // CocoaPods
+#if __has_include(<Braintree/BraintreeCore.h>) // CocoaPods
 #import <Braintree/BraintreeCard.h>
 #import <Braintree/BraintreePayPal.h>
 #import <Braintree/BraintreeVenmo.h>

--- a/Sources/BraintreeDropIn/BTPaymentSelectionViewController.m
+++ b/Sources/BraintreeDropIn/BTPaymentSelectionViewController.m
@@ -10,7 +10,7 @@
 #import "BTConfiguration+DropIn.h"
 #import "BTPaymentMethodNonce+DropIn.h"
 
-#ifdef COCOAPODS
+#if __has_include(<BraintreeDropIn/BraintreeDropIn.h>) // CocoaPods
 #import <Braintree/BraintreeCard.h>
 #import <Braintree/BraintreePayPal.h>
 #import <Braintree/BraintreeVenmo.h>

--- a/Sources/BraintreeDropIn/BTVaultManagementViewController.m
+++ b/Sources/BraintreeDropIn/BTVaultManagementViewController.m
@@ -5,7 +5,7 @@
 #import "BTPaymentMethodNonce+DropIn.h"
 #import "BTUIKAppearance.h"
 
-#if __has_include(<BraintreeDropIn/BraintreeDropIn.h>) // CocoaPods
+#if __has_include(<Braintree/BraintreeCore.h>) // CocoaPods
 #import <Braintree/BraintreeCard.h>
 #import <Braintree/BraintreeCore.h>
 #else

--- a/Sources/BraintreeDropIn/BTVaultManagementViewController.m
+++ b/Sources/BraintreeDropIn/BTVaultManagementViewController.m
@@ -5,7 +5,7 @@
 #import "BTPaymentMethodNonce+DropIn.h"
 #import "BTUIKAppearance.h"
 
-#ifdef COCOAPODS
+#if __has_include(<BraintreeDropIn/BraintreeDropIn.h>) // CocoaPods
 #import <Braintree/BraintreeCard.h>
 #import <Braintree/BraintreeCore.h>
 #else

--- a/Sources/BraintreeDropIn/Custom Views/BTUIPaymentMethodCollectionViewCell.h
+++ b/Sources/BraintreeDropIn/Custom Views/BTUIPaymentMethodCollectionViewCell.h
@@ -1,6 +1,6 @@
 #import <UIKit/UIKit.h>
 
-#ifdef COCOAPODS
+#if __has_include(<BraintreeDropIn/BraintreeDropIn.h>) // CocoaPods
 #import <Braintree/BTPaymentMethodNonce.h>
 #else
 #import <BraintreeCore/BTPaymentMethodNonce.h>

--- a/Sources/BraintreeDropIn/Custom Views/BTUIPaymentMethodCollectionViewCell.h
+++ b/Sources/BraintreeDropIn/Custom Views/BTUIPaymentMethodCollectionViewCell.h
@@ -1,6 +1,6 @@
 #import <UIKit/UIKit.h>
 
-#if __has_include(<BraintreeDropIn/BraintreeDropIn.h>) // CocoaPods
+#if __has_include(<Braintree/BraintreeCore.h>) // CocoaPods
 #import <Braintree/BTPaymentMethodNonce.h>
 #else
 #import <BraintreeCore/BTPaymentMethodNonce.h>

--- a/Sources/BraintreeDropIn/Helpers/BTConfiguration+DropIn.h
+++ b/Sources/BraintreeDropIn/Helpers/BTConfiguration+DropIn.h
@@ -1,4 +1,4 @@
-#ifdef COCOAPODS
+#if __has_include(<BraintreeDropIn/BraintreeDropIn.h>) // CocoaPods
 #import <Braintree/BraintreeCore.h>
 #else
 #import <BraintreeCore/BraintreeCore.h>

--- a/Sources/BraintreeDropIn/Helpers/BTConfiguration+DropIn.h
+++ b/Sources/BraintreeDropIn/Helpers/BTConfiguration+DropIn.h
@@ -1,4 +1,4 @@
-#if __has_include(<BraintreeDropIn/BraintreeDropIn.h>) // CocoaPods
+#if __has_include(<Braintree/BraintreeCore.h>) // CocoaPods
 #import <Braintree/BraintreeCore.h>
 #else
 #import <BraintreeCore/BraintreeCore.h>

--- a/Sources/BraintreeDropIn/Localization/BTDropInLocalization.m
+++ b/Sources/BraintreeDropIn/Localization/BTDropInLocalization.m
@@ -15,7 +15,7 @@ static NSArray *customTranslations;
         }
     }
 
-#ifdef COCOAPODS
+#if __has_include(<BraintreeDropIn/BraintreeDropIn.h>) // CocoaPods
     NSString *bundleName = @"BraintreeDropIn-Localization";
     NSString *localizationBundlePath = [NSBundle.mainBundle pathForResource:bundleName ofType:@"bundle"];
     if (!localizationBundlePath) {

--- a/Sources/BraintreeDropIn/Localization/BTDropInLocalization.m
+++ b/Sources/BraintreeDropIn/Localization/BTDropInLocalization.m
@@ -15,7 +15,7 @@ static NSArray *customTranslations;
         }
     }
 
-#if __has_include(<BraintreeDropIn/BraintreeDropIn.h>) // CocoaPods
+#if __has_include(<Braintree/BraintreeCore.h>) // CocoaPods
     NSString *bundleName = @"BraintreeDropIn-Localization";
     NSString *localizationBundlePath = [NSBundle.mainBundle pathForResource:bundleName ofType:@"bundle"];
     if (!localizationBundlePath) {

--- a/Sources/BraintreeDropIn/Models/BTDropInRequest.m
+++ b/Sources/BraintreeDropIn/Models/BTDropInRequest.m
@@ -1,5 +1,5 @@
 #import <BraintreeDropIn/BTDropInRequest.h>
-#if __has_include(<BraintreeDropIn/BraintreeDropIn.h>) // CocoaPods
+#if __has_include(<Braintree/BraintreeCore.h>) // CocoaPods
 #import <Braintree/BTPostalAddress.h>
 #else
 #import <BraintreeCore/BTPostalAddress.h>

--- a/Sources/BraintreeDropIn/Models/BTDropInRequest.m
+++ b/Sources/BraintreeDropIn/Models/BTDropInRequest.m
@@ -1,5 +1,5 @@
 #import <BraintreeDropIn/BTDropInRequest.h>
-#ifdef COCOAPODS
+#if __has_include(<BraintreeDropIn/BraintreeDropIn.h>) // CocoaPods
 #import <Braintree/BTPostalAddress.h>
 #else
 #import <BraintreeCore/BTPostalAddress.h>

--- a/Sources/BraintreeDropIn/Models/BTDropInResult.m
+++ b/Sources/BraintreeDropIn/Models/BTDropInResult.m
@@ -5,7 +5,7 @@
 #import "BTUIKVectorArtView.h"
 #import "BTUIKPaymentOptionCardView.h"
 
-#if __has_include(<BraintreeDropIn/BraintreeDropIn.h>) // CocoaPods
+#if __has_include(<Braintree/BraintreeCore.h>) // CocoaPods
 #import <Braintree/BraintreeCore.h>
 #else
 #import <BraintreeCore/BraintreeCore.h>

--- a/Sources/BraintreeDropIn/Models/BTDropInResult.m
+++ b/Sources/BraintreeDropIn/Models/BTDropInResult.m
@@ -5,7 +5,7 @@
 #import "BTUIKVectorArtView.h"
 #import "BTUIKPaymentOptionCardView.h"
 
-#ifdef COCOAPODS
+#if __has_include(<BraintreeDropIn/BraintreeDropIn.h>) // CocoaPods
 #import <Braintree/BraintreeCore.h>
 #else
 #import <BraintreeCore/BraintreeCore.h>

--- a/Sources/BraintreeDropIn/Public/BraintreeDropIn/BTDropInRequest.h
+++ b/Sources/BraintreeDropIn/Public/BraintreeDropIn/BTDropInRequest.h
@@ -1,6 +1,6 @@
 #import <BraintreeDropIn/BTDropInUICustomization.h>
 
-#if __has_include(<BraintreeDropIn/BraintreeDropIn.h>) // CocoaPods
+#if __has_include(<Braintree/BraintreeCore.h>) // CocoaPods
 #import <Braintree/BTPostalAddress.h>
 #import <Braintree/BTPayPalRequest.h>
 #import <Braintree/BTVenmoRequest.h>

--- a/Sources/BraintreeDropIn/Public/BraintreeDropIn/BTDropInRequest.h
+++ b/Sources/BraintreeDropIn/Public/BraintreeDropIn/BTDropInRequest.h
@@ -1,6 +1,6 @@
 #import <BraintreeDropIn/BTDropInUICustomization.h>
 
-#ifdef COCOAPODS
+#if __has_include(<BraintreeDropIn/BraintreeDropIn.h>) // CocoaPods
 #import <Braintree/BTPostalAddress.h>
 #import <Braintree/BTPayPalRequest.h>
 #import <Braintree/BTVenmoRequest.h>

--- a/Sources/BraintreeDropIn/Public/BraintreeDropIn/BraintreeDropIn.h
+++ b/Sources/BraintreeDropIn/Public/BraintreeDropIn/BraintreeDropIn.h
@@ -6,7 +6,7 @@ FOUNDATION_EXPORT double BraintreeDropInVersionNumber;
 //! Project version string for BraintreeUI.
 FOUNDATION_EXPORT const unsigned char BraintreeDropInVersionString[];
 
-#ifdef COCOAPODS
+#if __has_include(<BraintreeDropIn/BraintreeDropIn.h>) // CocoaPods
 #import <Braintree/BraintreeApplePay.h>
 #import <Braintree/BraintreeUnionPay.h>
 #import <Braintree/BraintreeVenmo.h>

--- a/Sources/BraintreeDropIn/Public/BraintreeDropIn/BraintreeDropIn.h
+++ b/Sources/BraintreeDropIn/Public/BraintreeDropIn/BraintreeDropIn.h
@@ -6,7 +6,7 @@ FOUNDATION_EXPORT double BraintreeDropInVersionNumber;
 //! Project version string for BraintreeUI.
 FOUNDATION_EXPORT const unsigned char BraintreeDropInVersionString[];
 
-#if __has_include(<BraintreeDropIn/BraintreeDropIn.h>) // CocoaPods
+#if __has_include(<Braintree/BraintreeCore.h>) // CocoaPods
 #import <Braintree/BraintreeApplePay.h>
 #import <Braintree/BraintreeUnionPay.h>
 #import <Braintree/BraintreeVenmo.h>


### PR DESCRIPTION


### Summary of changes

 - Fix an issue with projects that use SPM for Drop-in and CocoaPods for other dependencies. Since the `COCOAPODS` macro will be defined even though the project is using SPM, the wrong imports were being used. Addresses #325. 

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens 
- @scannillo 
