### PR TITLE
Add GitHub Actions workflow for publishing to CocoaPods

### DIFF
--- a/.github/workflows/publish_cocoapods.yml
+++ b/.github/workflows/publish_cocoapods.yml
@@ -1,0 +1,24 @@
+name: Publish to CocoaPods
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release"
+        required: true
+jobs:
+  release:
+    name: Release
+    runs-on: macOS-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Use Xcode 12.4
+        run: sudo xcode-select -switch /Applications/Xcode_12.4.app
+
+      - name: Publish to CocoaPods
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        run: pod trunk push BraintreeDropIn.podspec


### PR DESCRIPTION


### Summary of changes

 - Our release workflow failed on the step to publish to CocoaPods yesterday, so we're adding a workflow that only does that step to see if it'll work today.

 ### Checklist

 - ~Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens 
