### PR TITLE
Fix bug with canceling out of PayPal flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Braintree iOS Drop-in SDK - Release Notes
 
+## unreleased
+
+* PayPal
+  * Fix bug where an error was returned if the user canceled the PayPal flow, instead of remaining on the payment selection sheet
+
 ## 9.0.1 (2021-05-03)
 
 * VoiceOver improvements

--- a/Demo.xcodeproj/project.pbxproj
+++ b/Demo.xcodeproj/project.pbxproj
@@ -276,9 +276,9 @@
 			isa = PBXGroup;
 			children = (
 				8068E52B256D7459002904E6 /* BraintreeDropIn_EditMode_UITests.swift */,
+				805384C8261623E20085B16C /* BraintreeDropIn_Localization_UITests.swift */,
 				8068E51F256D73D5002904E6 /* BraintreeDropIn_UITests.swift */,
 				428484CA2617C1160093461D /* BraintreeDropIn_Venmo_UITests.swift */,
-				805384C8261623E20085B16C /* BraintreeDropIn_Localization_UITests.swift */,
 				8068E531256D7489002904E6 /* Helpers.swift */,
 				8068E521256D73D5002904E6 /* Info.plist */,
 			);

--- a/Demo/Application/DemoDropInViewController.swift
+++ b/Demo/Application/DemoDropInViewController.swift
@@ -78,6 +78,7 @@ class DemoDropInViewController: DemoBaseViewController, DemoDropInViewDelegate {
             guard let result = result, error == nil else {
                 self.progressBlock?("Error: \(error!.localizedDescription)")
                 print("Error: \(error!)")
+                dropInController.dismiss(animated: true, completion: nil)
                 return
             }
             

--- a/Demo/UITests/BraintreeDropIn_Venmo_UITests.swift
+++ b/Demo/UITests/BraintreeDropIn_Venmo_UITests.swift
@@ -38,7 +38,7 @@ class Venmo_UITests: XCTestCase {
         waitForElementToAppear(mockVenmo.buttons["ERROR"])
         mockVenmo.buttons["ERROR"].tap()
 
-        waitForElementToAppear(demoApp.staticTexts["Select Payment Method"])
+        waitForElementToAppear(demoApp.staticTexts["Add Payment Method"])
     }
 
     func testTokenizeVenmo_whenUserCancels_returnsCancel() {
@@ -48,7 +48,7 @@ class Venmo_UITests: XCTestCase {
         waitForElementToAppear(mockVenmo.buttons["Cancel"])
         mockVenmo.buttons["Cancel"].tap()
 
-        waitForElementToAppear(demoApp.staticTexts["Select Payment Method"])
+        waitForElementToAppear(demoApp.staticTexts["Add Payment Method"])
     }
 }
 

--- a/Sources/BraintreeDropIn/BTPaymentSelectionViewController.m
+++ b/Sources/BraintreeDropIn/BTPaymentSelectionViewController.m
@@ -289,7 +289,8 @@ static BOOL _vaultedCardAppearAnalyticSent = NO;
         [self showLoadingScreen:YES];
         [driver tokenizePayPalAccountWithPayPalRequest:payPalRequest completion:^(BTPayPalAccountNonce * _Nullable tokenizedPayPalAccount, NSError * _Nullable error) {
             [self showLoadingScreen:NO];
-            if (self.delegate && (tokenizedPayPalAccount != nil || error != nil)) {
+            BOOL shouldReturnError = (error != nil && error.code != BTPayPalDriverErrorTypeCanceled);
+            if (self.delegate && (tokenizedPayPalAccount != nil || shouldReturnError)) {
                 [self.delegate selectionCompletedWithPaymentMethodType:BTDropInPaymentMethodTypePayPal nonce:tokenizedPayPalAccount error:error];
             }
         }];


### PR DESCRIPTION


### Summary of changes

 - Fix a bug where we returned an error to the merchant if the user canceled out of the PayPal flow, instead of remaining on the payment selection sheet. 

**Context**: In v5, the Braintree SDK returns an error with the code `BTPayPalDriverErrorTypeCanceled` if the user cancels the PayPal flow. The PR updates Drop-in to check for that error code and do nothing if it's returned, so that the user can select a different payment method.

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sestevens 
