### PR TITLE
Increase Discover Card Range to 19 Digits

### DIFF
--- a/BraintreeDropIn.podspec
+++ b/BraintreeDropIn.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
                        Check out our development portal at https://developers.braintreepayments.com.
   DESC
   s.homepage         = "https://www.braintreepayments.com/how-braintree-works"
-  s.documentation_url = "https://developers.braintreepayments.com/ios/start/hello-client"
+  s.documentation_url = "https://developer.paypal.com/braintree/docs/start/hello-client/ios/v5"
   s.screenshots      = ["https://github.com/braintree/braintree-ios-drop-in/raw/master/Images/client-sdk-ios-series-light.png", "https://github.com/braintree/braintree-ios-drop-in/raw/master/Images/client-sdk-ios-series-dark.png"]
   s.license          = "MIT"
   s.author           = { "Braintree" => "code@getbraintree.com" }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Braintree iOS Drop-in SDK - Release Notes
 
 ## unreleased
-
 * Increase valid Discover card length to 19 digits
 
 ## 9.0.2 (2021-05-26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS Drop-in SDK - Release Notes
 
+## unreleased
+
+* Increase valid Discover card length to 19 digits
+
 ## 9.0.2 (2021-05-26)
 * Require `braintree_ios` v5.3.2 or higher
 * PayPal

--- a/Sources/BraintreeDropIn/Models/BTUIKCardType.m
+++ b/Sources/BraintreeDropIn/Models/BTUIKCardType.m
@@ -162,7 +162,7 @@
                                                         securityCodeName:BTDropInLocalizedString(CVC_FIELD_PLACEHOLDER)
                                                                 prefixes:@[@"^(5[1-5]|222[1-9]|22[3-9]|2[3-6]|27[0-1]|2720)\\d*"]];
         BTUIKCardType *discover = [[BTUIKCardType alloc] initWithBrand:BTDropInLocalizedString(CARD_TYPE_DISCOVER)
-                                                        securityCodeName:BTDropInLocalizedString(CVV_FIELD_PLACEHOLDER)
+                                                        securityCodeName:BTDropInLocalizedString(CID_FIELD_PLACEHOLDER)
                                                                 prefixes:@[@"^(6011|65|64[4-9]|622)\\d*"]
                                                          relaxedPrefixes:nil
                                                       validNumberLengths:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(16, 4)]

--- a/Sources/BraintreeDropIn/Models/BTUIKCardType.m
+++ b/Sources/BraintreeDropIn/Models/BTUIKCardType.m
@@ -162,8 +162,12 @@
                                                         securityCodeName:BTDropInLocalizedString(CVC_FIELD_PLACEHOLDER)
                                                                 prefixes:@[@"^(5[1-5]|222[1-9]|22[3-9]|2[3-6]|27[0-1]|2720)\\d*"]];
         BTUIKCardType *discover = [[BTUIKCardType alloc] initWithBrand:BTDropInLocalizedString(CARD_TYPE_DISCOVER)
-                                                      securityCodeName:BTDropInLocalizedString(CID_FIELD_PLACEHOLDER)
-                                                              prefixes:@[@"^(6011|65|64[4-9]|622)\\d*"]];
+                                                        securityCodeName:BTDropInLocalizedString(CVV_FIELD_PLACEHOLDER)
+                                                                prefixes:@[@"^(6011|65|64[4-9]|622)\\d*"]
+                                                         relaxedPrefixes:nil
+                                                      validNumberLengths:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(16, 4)]
+                                                          validCvvLength:3
+                                                            formatSpaces:kDefaultFormatSpaceIndices];
         BTUIKCardType *jcb = [[BTUIKCardType alloc] initWithBrand:BTDropInLocalizedString(CARD_TYPE_JCB)
                                                  securityCodeName:BTDropInLocalizedString(CVV_FIELD_PLACEHOLDER)
                                                          prefixes:@[@"^35\\d*"]];

--- a/Sources/BraintreeDropIn/Models/BTUIKCardType.m
+++ b/Sources/BraintreeDropIn/Models/BTUIKCardType.m
@@ -162,12 +162,12 @@
                                                         securityCodeName:BTDropInLocalizedString(CVC_FIELD_PLACEHOLDER)
                                                                 prefixes:@[@"^(5[1-5]|222[1-9]|22[3-9]|2[3-6]|27[0-1]|2720)\\d*"]];
         BTUIKCardType *discover = [[BTUIKCardType alloc] initWithBrand:BTDropInLocalizedString(CARD_TYPE_DISCOVER)
-                                                        securityCodeName:BTDropInLocalizedString(CID_FIELD_PLACEHOLDER)
-                                                                prefixes:@[@"^(6011|65|64[4-9]|622)\\d*"]
-                                                         relaxedPrefixes:nil
-                                                      validNumberLengths:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(16, 4)]
-                                                          validCvvLength:3
-                                                            formatSpaces:kDefaultFormatSpaceIndices];
+                                                      securityCodeName:BTDropInLocalizedString(CID_FIELD_PLACEHOLDER)
+                                                              prefixes:@[@"^(6011|65|64[4-9]|622)\\d*"]
+                                                       relaxedPrefixes:nil
+                                                    validNumberLengths:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(16, 4)]
+                                                        validCvvLength:3
+                                                          formatSpaces:kDefaultFormatSpaceIndices];
         BTUIKCardType *jcb = [[BTUIKCardType alloc] initWithBrand:BTDropInLocalizedString(CARD_TYPE_JCB)
                                                  securityCodeName:BTDropInLocalizedString(CVV_FIELD_PLACEHOLDER)
                                                          prefixes:@[@"^35\\d*"]];

--- a/UnitTests/BTUIKCardTypeTests.m
+++ b/UnitTests/BTUIKCardTypeTests.m
@@ -34,6 +34,7 @@
     // Discover
     [sampleCards addObject:@[@"6011111111111117", @"Discover"]];
     [sampleCards addObject:@[@"6011000990139424", @"Discover"]];
+    [sampleCards addObject:@[@"6500000000000000003", @"Discover"]];
 
     // Amex
     [sampleCards addObject:@[@"378282246310005", @"American Express"]];


### PR DESCRIPTION
### Summary of changes

 - Increase valid Discover card length to 19 digits
 - Note: I couldn't find a valid Discover test card for that is greater than 16 digits, so was not able to end-to-end test this

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sarahkoop 
