### PR TITLE
Xcode13-beta3 Fix

### DIFF
--- a/BraintreeDropIn.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BraintreeDropIn.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,9 +5,9 @@
         "package": "braintree_ios",
         "repositoryURL": "https://github.com/braintree/braintree_ios",
         "state": {
-          "branch": null,
-          "revision": "6be5b6ceabe6acf3353a986da272bc604c8cd010",
-          "version": "5.4.2"
+          "branch": "master",
+          "revision": "ca0cbc19dc767ae5f1c757101437cd7c1e482976",
+          "version": null
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/futuretap/InAppSettingsKit.git",
         "state": {
           "branch": null,
-          "revision": "e4985e0dc0de36f12801f67cc984b3d1cb7f3d52",
-          "version": "3.3.1"
+          "revision": "71e03ebad8462618f96c575c86d2e9220f880676",
+          "version": "3.3.2"
         }
       }
     ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 * Add `deviceData` to `BTDropInResult`
+* Swift Package Manager
+  * Adds `NS_EXTENSION_UNAVAILABLE` annotations to methods unavailable for use in app extensions (fixes #343 for Xcode 13-beta3)
 
 ## 9.1.0 (2021-07-01)
 * Increase valid Discover card length to 19 digits

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 * Add `deviceData` to `BTDropInResult`
+* Require `braintree_ios` 5.4.3 or higher (includes Xcode 13-beta3 fixes)
 * Swift Package Manager
   * Adds `NS_EXTENSION_UNAVAILABLE` annotations to methods unavailable for use in app extensions (fixes #343 for Xcode 13-beta3)
 

--- a/Demo.xcodeproj/project.pbxproj
+++ b/Demo.xcodeproj/project.pbxproj
@@ -907,7 +907,7 @@
 			repositoryURL = "https://github.com/futuretap/InAppSettingsKit.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 3.1.8;
+				minimumVersion = 3.0.0;
 			};
 		};
 		8021E365268A1CB4003BBA53 /* XCRemoteSwiftPackageReference "braintree-ios-drop-in" */ = {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,9 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "Braintree", url: "https://github.com/braintree/braintree_ios", from: "5.4.2")
+        //.package(name: "Braintree", url: "https://github.com/braintree/braintree_ios", from: "5.4.2")
+        .package(name: "Braintree", url: "https://github.com/braintree/braintree_ios", .branch("master")
+)
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -14,10 +14,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        // TODO: Update to use latest release of braintree_ios
-        //.package(name: "Braintree", url: "https://github.com/braintree/braintree_ios", from: "5.4.2")
-        .package(name: "Braintree", url: "https://github.com/braintree/braintree_ios", .branch("master")
-)
+        .package(name: "Braintree", url: "https://github.com/braintree/braintree_ios", from: "5.4.3")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,7 @@ let package = Package(
         )
     ],
     dependencies: [
+        // TODO: Update to use latest release of braintree_ios
         //.package(name: "Braintree", url: "https://github.com/braintree/braintree_ios", from: "5.4.2")
         .package(name: "Braintree", url: "https://github.com/braintree/braintree_ios", .branch("master")
 )

--- a/Sources/BraintreeDropIn/BTPaymentSelectionViewController.m
+++ b/Sources/BraintreeDropIn/BTPaymentSelectionViewController.m
@@ -162,7 +162,7 @@ static BOOL _vaultedCardAppearAnalyticSent = NO;
 
 - (id)application NS_EXTENSION_UNAVAILABLE("Uses APIs (i.e UIApplication.sharedApplication) not available for use in App Extensions.") {
     if (!_application) {
-        _application = [UIApplication sharedApplication];
+        _application = UIApplication.sharedApplication;
     }
     return _application;
 }

--- a/Sources/BraintreeDropIn/BTPaymentSelectionViewController.m
+++ b/Sources/BraintreeDropIn/BTPaymentSelectionViewController.m
@@ -160,7 +160,7 @@ static BOOL _vaultedCardAppearAnalyticSent = NO;
 
 #pragma mark - Accessors
 
-- (id)application {
+- (id)application NS_EXTENSION_UNAVAILABLE("Uses APIs (i.e UIApplication.sharedApplication) not available for use in App Extensions.") {
     if (!_application) {
         _application = [UIApplication sharedApplication];
     }

--- a/Sources/BraintreeDropIn/BTVaultManagementViewController.m
+++ b/Sources/BraintreeDropIn/BTVaultManagementViewController.m
@@ -93,10 +93,10 @@ NSString *const BTGraphQLDeletePaymentMethodFromSingleUseToken = @""
         return;
     }
 
-    [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:YES];
+    [UIApplication.sharedApplication setNetworkActivityIndicatorVisible:YES];
 
     [self.apiClient fetchPaymentMethodNonces:YES completion:^(NSArray<BTPaymentMethodNonce *> *paymentMethodNonces, NSError *error) {
-        [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];
+        [UIApplication.sharedApplication setNetworkActivityIndicatorVisible:NO];
 
         if (error) {
             // no action

--- a/Sources/BraintreeDropIn/BTVaultManagementViewController.m
+++ b/Sources/BraintreeDropIn/BTVaultManagementViewController.m
@@ -84,7 +84,7 @@ NSString *const BTGraphQLDeletePaymentMethodFromSingleUseToken = @""
     }
 }
 
-- (void)fetchPaymentMethodsOnCompletion:(void(^)(void))completionBlock {
+- (void)fetchPaymentMethodsOnCompletion:(void(^)(void))completionBlock NS_EXTENSION_UNAVAILABLE("Uses APIs (i.e UIApplication.sharedApplication) not available for use in App Extensions.") {
     if (!self.apiClient.clientToken) {
         self.paymentMethodNonces = @[];
         if (completionBlock) {

--- a/Sources/BraintreeDropIn/Helpers/BTUIKViewUtil.m
+++ b/Sources/BraintreeDropIn/Helpers/BTUIKViewUtil.m
@@ -234,7 +234,7 @@
     }
 }
 
-+ (BOOL)isLanguageLayoutDirectionRightToLeft {
++ (BOOL)isLanguageLayoutDirectionRightToLeft NS_EXTENSION_UNAVAILABLE("Uses APIs (i.e UIApplication.sharedApplication) not available for use in App Extensions.") {
     return [UIApplication sharedApplication].userInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft;
 }
 
@@ -246,7 +246,7 @@
     return [self isLanguageLayoutDirectionRightToLeft] ? NSTextAlignmentLeft : NSTextAlignmentRight;
 }
 
-+ (UIWindowScene *)activeWindowScene API_AVAILABLE(ios(13.0)) {
++ (UIWindowScene *)activeWindowScene API_AVAILABLE(ios(13.0)) NS_EXTENSION_UNAVAILABLE("Uses APIs (i.e UIApplication.sharedApplication) not available for use in App Extensions.") {
     for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
         if (scene.activationState == UISceneActivationStateForegroundActive) {
             return (UIWindowScene *)scene;
@@ -256,7 +256,7 @@
     return nil;
 }
 
-+ (BOOL)isOrientationLandscape {
++ (BOOL)isOrientationLandscape NS_EXTENSION_UNAVAILABLE("Uses APIs (i.e UIApplication.sharedApplication) not available for use in App Extensions.") {
     if (@available(iOS 13, *)) {
         return UIInterfaceOrientationIsLandscape([self activeWindowScene].interfaceOrientation);
     } else {
@@ -264,7 +264,7 @@
     }
 }
 
-+ (CGFloat)statusBarHeight {
++ (CGFloat)statusBarHeight NS_EXTENSION_UNAVAILABLE("Uses APIs (i.e UIApplication.sharedApplication) not available for use in App Extensions.") {
     if (@available(iOS 13, *)) {
         return CGRectGetHeight([self activeWindowScene].statusBarManager.statusBarFrame);
     } else {

--- a/Sources/BraintreeDropIn/Helpers/BTUIKViewUtil.m
+++ b/Sources/BraintreeDropIn/Helpers/BTUIKViewUtil.m
@@ -235,7 +235,7 @@
 }
 
 + (BOOL)isLanguageLayoutDirectionRightToLeft NS_EXTENSION_UNAVAILABLE("Uses APIs (i.e UIApplication.sharedApplication) not available for use in App Extensions.") {
-    return [UIApplication sharedApplication].userInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft;
+    return UIApplication.sharedApplication.userInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft;
 }
 
 + (NSTextAlignment)naturalTextAlignment {


### PR DESCRIPTION
### Background
 - [Sister PR in `braintree_ios`](https://github.com/braintree/braintree_ios/pull/713)
 - Result of GH Issue #343 
 - [XCode 13-beta3](https://developer.apple.com/documentation/xcode-release-notes/xcode-13-beta-release-notes) release notes call out the following change:
     > Linking Swift packages from application extension targets or watchOS applications no longer emits unresolvable warnings about linking to libraries not safe for use in application extensions. This means that code referencing APIs annotated as unavailable for use in app extensions must now themselves be annotated as unavailable for use in application extensions, in order to allow that code to be used in both apps and app extensions. (66928265)


### Changes

- In places that we use Apple APIs which aren't usable in App Extensions (`UIApplication.sharedApplication`) we need to explicitly mark these methods as not usable for App Extensions.
- Use dot syntax when available.
- Bump InAppSettingsKit (used for Demo app) to[ v3.3.2 which includes XCode13-beta3 fixes.](https://github.com/futuretap/InAppSettingsKit/issues/456)

 ### Checklist

 - [X] Added a changelog entry

### Authors
@scannillo 