### PR TITLE
v8 - iOS 15 UI Updates

### DIFF
--- a/BraintreeDropIn/BTCardFormViewController.m
+++ b/BraintreeDropIn/BTCardFormViewController.m
@@ -80,6 +80,9 @@
     self.unionPayEnabledMerchant = NO;
     self.formFields = @[];
     self.view.backgroundColor = [BTUIKAppearance sharedInstance].formBackgroundColor;
+    if (@available(iOS 15.0, *)) {
+        self.navigationController.navigationBar.scrollEdgeAppearance = self.navigationController.navigationBar.standardAppearance;
+    }
     self.navigationController.navigationBar.barTintColor = [BTUIKAppearance sharedInstance].barBackgroundColor;
     self.navigationController.navigationBar.translucent = NO;
     [self.navigationController.navigationBar setTitleTextAttributes:@{

--- a/BraintreeDropIn/BTVaultManagementViewController.m
+++ b/BraintreeDropIn/BTVaultManagementViewController.m
@@ -31,6 +31,9 @@ NSString *const BTGraphQLDeletePaymentMethodFromSingleUseToken = @""
     [super viewDidLoad];
 
     self.view.backgroundColor = [BTUIKAppearance sharedInstance].formBackgroundColor;
+    if (@available(iOS 15.0, *)) {
+        self.navigationController.navigationBar.scrollEdgeAppearance = self.navigationController.navigationBar.standardAppearance;
+    }
     self.navigationController.navigationBar.barTintColor = [BTUIKAppearance sharedInstance].barBackgroundColor;
     self.navigationController.navigationBar.translucent = NO;
     [self.navigationController.navigationBar setTitleTextAttributes:@{

--- a/BraintreeDropIn/Custom Views/BTEnrollmentVerificationViewController.m
+++ b/BraintreeDropIn/Custom Views/BTEnrollmentVerificationViewController.m
@@ -32,6 +32,9 @@
     self.title = BTUIKLocalizedString(CONFIRM_ENROLLMENT_LABEL);
     
     self.view.backgroundColor = [BTUIKAppearance sharedInstance].formBackgroundColor;
+    if (@available(iOS 15.0, *)) {
+        self.navigationController.navigationBar.scrollEdgeAppearance = self.navigationController.navigationBar.standardAppearance;
+    }
     self.navigationController.navigationBar.barTintColor = [BTUIKAppearance sharedInstance].barBackgroundColor;
     self.navigationController.navigationBar.translucent = NO;
     [self.navigationController.navigationBar setTitleTextAttributes:@{

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS Drop-in SDK - Release Notes
 
+## unreleased
+* iOS 15 Support
+  * Update `scrollEdgeAppearance` based on iOS 15 changes
+
 ## 8.1.4 (2021-03-25)
 
 * Cards

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -25,16 +25,16 @@ PODS:
   - Braintree/Venmo (4.36.1):
     - Braintree/Core
     - Braintree/PayPalDataCollector
-  - BraintreeDropIn (8.1.3):
-    - BraintreeDropIn/DropIn (= 8.1.3)
-  - BraintreeDropIn/DropIn (8.1.3):
+  - BraintreeDropIn (8.1.4):
+    - BraintreeDropIn/DropIn (= 8.1.4)
+  - BraintreeDropIn/DropIn (8.1.4):
     - Braintree/Card (~> 4.32)
     - Braintree/Core (~> 4.32)
     - Braintree/PaymentFlow (~> 4.32)
     - Braintree/PayPal (~> 4.32)
     - Braintree/UnionPay (~> 4.32)
     - BraintreeDropIn/UIKit
-  - BraintreeDropIn/UIKit (8.1.3)
+  - BraintreeDropIn/UIKit (8.1.4)
   - Expecta (1.0.6)
   - InAppSettingsKit (3.1.2)
   - OCMock (3.6)
@@ -83,7 +83,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Braintree: f7e0e9a5030e22b8ad77e617f27ac9327d7bc004
-  BraintreeDropIn: 92e960ee1e0a0ea3e722d494ff1e78699ca6c6b9
+  BraintreeDropIn: 073ef11637285efc5572b412079a34942c849ef9
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   InAppSettingsKit: 988142fed825524ae44dd0d93684daf8f0358b8c
   OCMock: 5ea90566be239f179ba766fd9fbae5885040b992
@@ -91,6 +91,6 @@ SPEC CHECKSUMS:
   Specta: 3e1bd89c3517421982dc4d1c992503e48bd5fe66
   xcbeautify: 34e667aac66c3357794431c9dd4037808cdab025
 
-PODFILE CHECKSUM: b3466ae78029e6da95f99053b2cefa2b79b9e8af
+PODFILE CHECKSUM: 285659a8ec88dbefda5d88e63a77b493b17eef5b
 
 COCOAPODS: 1.10.0


### PR DESCRIPTION
### Summary of changes
 - Update UI to use `scrollEdgeAppearance` based on iOS 15 changes see [Apple developer forum discussion](https://developer.apple.com/forums/thread/682420)

 ### Checklist

 - [x] Added a changelog entry

### Note
We are still blocked by Cardinal on fixing this UI issue for the 3DS 2 challenge screen. We opened a ticket with them ~2 months ago. So far no updates, I just poked today.

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @scannillo 

### Before Screenshots
![Screen Shot 2021-08-25 at 11 25 18 AM](https://user-images.githubusercontent.com/35243507/130830394-0c81356e-f278-4f58-b836-5d9887a870be.png)
![Screen Shot 2021-08-25 at 11 25 08 AM](https://user-images.githubusercontent.com/35243507/130830400-66dcdf7e-04c2-4d04-b5f3-200fd34abae8.png)
![Screen Shot 2021-08-25 at 11 24 56 AM](https://user-images.githubusercontent.com/35243507/130830403-aa2d3a45-19c7-4ae9-a094-83347bc66ddb.png)

### After Screenshots

![Screen Shot 2021-08-25 at 11 33 27 AM](https://user-images.githubusercontent.com/35243507/130830426-e6203146-500e-43cd-a986-6d86bc26382a.png)
![Screen Shot 2021-08-25 at 11 32 31 AM](https://user-images.githubusercontent.com/35243507/130830435-1d901576-44de-4d65-8bbd-f04dff5efe7e.png)
![Screen Shot 2021-08-25 at 11 32 21 AM](https://user-images.githubusercontent.com/35243507/130830438-8e67fe9f-45cd-4445-b6a9-a86f87caa6b1.png)
