### PR TITLE
Fix "current" section of reference docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,15 +65,19 @@ jobs:
       - name: Publish reference docs
         run: |
           gem install jazzy
+          brew install sourcekitten
+          sourcekitten doc --objc Docs/Braintree-Braintree-Drop-In-Umbrella-Header.h -- \
+            -x objective-c -isysroot $(xcrun --show-sdk-path --sdk iphonesimulator) \
+            -I $(pwd)/Sources/BraintreeDropIn/Public \
+            > objcDoc.json
           jazzy \
-            --objc \
+            --sourcekitten-sourcefile objcDoc.json \
             --author Braintree \
             --author_url http://braintreepayments.com \
             --github_url https://github.com/braintree/braintree-ios-drop-in \
             --github-file-prefix https://github.com/braintree/braintree-ios-drop-in/tree/${{ github.event.inputs.version }} \
             --theme fullwidth \
-            --output ${{ github.event.inputs.version }} \
-            --xcodebuild-arguments --objc,BraintreeDropIn-Umbrella-Header.h,--,-x,objective-c,-isysroot,$(xcrun --sdk iphonesimulator --show-sdk-path),-I,$(pwd)/Sources/BraintreeDropIn/Public
+            --output ${{ github.event.inputs.version }}
           cp -R Images ${{ github.event.inputs.version }}/Images
           git checkout gh-pages
           ln -sfn ${{ github.event.inputs.version }} current

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           gem install jazzy
           brew install sourcekitten
-          sourcekitten doc --objc Docs/Braintree-Braintree-Drop-In-Umbrella-Header.h -- \
+          sourcekitten doc --objc Docs/BraintreeDropIn-Umbrella-Header.h -- \
             -x objective-c -isysroot $(xcrun --show-sdk-path --sdk iphonesimulator) \
             -I $(pwd)/Sources/BraintreeDropIn/Public \
             > objcDoc.json
@@ -84,3 +84,4 @@ jobs:
           git add current ${{ github.event.inputs.version }}
           git commit -m "Publish ${{ github.event.inputs.version }} docs to github pages"
           git push
+q

--- a/BraintreeDropIn-Umbrella-Header.h
+++ b/BraintreeDropIn-Umbrella-Header.h
@@ -1,1 +1,0 @@
-#import <BraintreeDropIn/BraintreeDropIn.h>

--- a/Docs/Braintree-Drop-In-Umbrella-Header.h
+++ b/Docs/Braintree-Drop-In-Umbrella-Header.h
@@ -1,0 +1,1 @@
+#import <BraintreeDropIn/BraintreeDropIn.h>

--- a/Docs/Braintree-Drop-In-Umbrella-Header.h
+++ b/Docs/Braintree-Drop-In-Umbrella-Header.h
@@ -1,1 +1,0 @@
-#import <BraintreeDropIn/BraintreeDropIn.h>

--- a/Docs/BraintreeDropIn-Umbrella-Header.h
+++ b/Docs/BraintreeDropIn-Umbrella-Header.h
@@ -1,0 +1,1 @@
+#import <BraintreeDropIn/BraintreeDropIn.h> 

--- a/Rakefile
+++ b/Rakefile
@@ -42,7 +42,7 @@ class << self
   end
 
   def current_version
-    File.read(PODSPEC)[SEMVER]
+    "9.2.0"
   end
 
   def current_version_with_sha

--- a/Rakefile
+++ b/Rakefile
@@ -240,7 +240,7 @@ namespace :docs do
     run! "rm -rf docs_output"
     run(sourcekitten_objc_command)
     run(jazzy_command)
-    run! "rm swiftDoc.json && rm objcDoc.json"
+    run! "rm objcDoc.json"
     puts "Generated HTML documentation"
   end
 

--- a/Rakefile
+++ b/Rakefile
@@ -205,14 +205,21 @@ end
 
 def jazzy_command
   %W[jazzy
-      --objc
+      --sourcekitten-sourcefile swiftDoc.json,objcDoc.json
       --author Braintree
       --author_url http://braintreepayments.com
       --github_url https://github.com/braintree/braintree-ios-drop-in
       --github-file-prefix https://github.com/braintree/braintree-ios-drop-in/tree/#{current_version}
       --theme fullwidth
       --output #{current_version}
-      --xcodebuild-arguments --objc,BraintreeDropIn-Umbrella-Header.h,--,-x,objective-c,-isysroot,$(xcrun --sdk iphonesimulator --show-sdk-path),-I,$(pwd)/Sources/BraintreeDropIn/Public
+  ].join(' ')
+end
+
+def sourcekitten_objc_command
+  %W[sourcekitten doc --objc Docs/Braintree-Drop-In-Umbrella-Header.h --
+      -x objective-c -isysroot $(xcrun --show-sdk-path --sdk iphonesimulator)
+      -I $(pwd)/Sources/BraintreeDropIn/Public
+      > objcDoc.json
   ].join(' ')
 end
 
@@ -223,19 +230,48 @@ namespace :docs do
 
   desc "Generate docs with jazzy"
   task :generate do
+    begin
+      run! "sourcekitten --version"
+    rescue => e
+      say(HighLine.color("Please run `brew install sourcekitten`", :red, :bold))
+      raise
+    end
+
+    run! "rm -rf docs_output"
+    run(sourcekitten_objc_command)
     run(jazzy_command)
-    run! "cp -R Images #{current_version}/Images" # copy images used in README
+    run! "rm swiftDoc.json && rm objcDoc.json"
     puts "Generated HTML documentation"
   end
 
   task :publish do
-  	version = current_version
     run! "git checkout gh-pages"
-    run! "ln -sfn #{version} current" # update symlink to current version
-    run! "git add current #{version}"
-    run! "git commit -m 'Publish #{version} docs to github pages'"
+    run! "ln -sfn #{current_version} current" # update symlink to current version
+    run! "git add current #{current_version}"
+    run! "git commit -m 'Publish #{current_version} docs to github pages'"
     run! "git push"
     run! "git checkout -"
     puts "Published docs to github pages"
   end
 end
+
+# namespace :docs do
+
+#   desc "Generate docs with jazzy"
+#   task :generate do
+#     run(jazzy_command)
+#     run! "cp -R Images #{current_version}/Images" # copy images used in README
+#     puts "Generated HTML documentation"
+#   end
+
+#   task :publish do
+#   	version = current_version
+#     run! "git checkout gh-pages"
+#     run! "ln -sfn #{version} current" # update symlink to current version
+#     run! "git add current #{version}"
+#     run! "git commit -m 'Publish #{version} docs to github pages'"
+#     run! "git push"
+#     run! "git checkout -"
+#     puts "Published docs to github pages"
+#   end
+# end

--- a/Rakefile
+++ b/Rakefile
@@ -216,7 +216,7 @@ def jazzy_command
 end
 
 def sourcekitten_objc_command
-  %W[ sourcekitten doc --objc Docs/Braintree-Drop-In-Umbrella-Header.h -- 
+  %W[ sourcekitten doc --objc Docs/BraintreeDropIn-Umbrella-Header.h -- 
       -x objective-c -isysroot $(xcrun --show-sdk-path --sdk iphonesimulator)
       -I $(pwd)/Sources/BraintreeDropIn/Public
       > objcDoc.json

--- a/Rakefile
+++ b/Rakefile
@@ -42,7 +42,7 @@ class << self
   end
 
   def current_version
-    "9.2.0"
+    File.read(PODSPEC)[SEMVER]
   end
 
   def current_version_with_sha

--- a/Rakefile
+++ b/Rakefile
@@ -216,8 +216,8 @@ def jazzy_command
 end
 
 def sourcekitten_objc_command
-  %W[
-sourcekitten doc --objc Docs/Braintree-Drop-In-Umbrella-Header.h --      -x objective-c -isysroot $(xcrun --show-sdk-path --sdk iphonesimulator)
+  %W[ sourcekitten doc --objc Docs/Braintree-Drop-In-Umbrella-Header.h -- 
+      -x objective-c -isysroot $(xcrun --show-sdk-path --sdk iphonesimulator)
       -I $(pwd)/Sources/BraintreeDropIn/Public
       > objcDoc.json
   ].join(' ')

--- a/Rakefile
+++ b/Rakefile
@@ -216,8 +216,8 @@ def jazzy_command
 end
 
 def sourcekitten_objc_command
-  %W[sourcekitten doc --objc Docs/Braintree-Drop-In-Umbrella-Header.h --
-      -x objective-c -isysroot $(xcrun --show-sdk-path --sdk iphonesimulator)
+  %W[
+sourcekitten doc --objc Docs/Braintree-Drop-In-Umbrella-Header.h --      -x objective-c -isysroot $(xcrun --show-sdk-path --sdk iphonesimulator)
       -I $(pwd)/Sources/BraintreeDropIn/Public
       > objcDoc.json
   ].join(' ')
@@ -241,6 +241,7 @@ namespace :docs do
     run(sourcekitten_objc_command)
     run(jazzy_command)
     run! "rm objcDoc.json"
+    run! "cp -R Images #{current_version}/Images" # copy images used in README
     puts "Generated HTML documentation"
   end
 
@@ -254,24 +255,3 @@ namespace :docs do
     puts "Published docs to github pages"
   end
 end
-
-# namespace :docs do
-
-#   desc "Generate docs with jazzy"
-#   task :generate do
-#     run(jazzy_command)
-#     run! "cp -R Images #{current_version}/Images" # copy images used in README
-#     puts "Generated HTML documentation"
-#   end
-
-#   task :publish do
-#   	version = current_version
-#     run! "git checkout gh-pages"
-#     run! "ln -sfn #{version} current" # update symlink to current version
-#     run! "git add current #{version}"
-#     run! "git commit -m 'Publish #{version} docs to github pages'"
-#     run! "git push"
-#     run! "git checkout -"
-#     puts "Published docs to github pages"
-#   end
-# end


### PR DESCRIPTION
### Summary

Issue: The reference docs with "current" in their path for https://braintree.github.io/braintree-ios-drop-in/current/ was no accurately pointing to the latest version of the SDK. The reason it is now, is because I tested the following changes in this PR manually, via the Rakefile. Now the "current" section looks good.

### Changes

The changes really just update our jazzy workflow to use source-kitten, which the `braintree_ios` SDK was already doing. I honestly just copy pasted, then modified. At our next release, we can confirm that the `release.yml` changes work as expected.

- Updates Rakefile
- Update release.yml
- Move umbrella header to `Docs/` dir to mirror `braintree_ios` process

 ### Checklist

 - ~Added a changelog entry~
 - JIRA #DTBTSDK-1210

### Authors
@scannillo
