### PR TITLE
Fix iOS 15 Payment Method Icon Border Bug

### DIFF
--- a/Sources/BraintreeDropIn/Components/BTUIKPaymentOptionCardView.m
+++ b/Sources/BraintreeDropIn/Components/BTUIKPaymentOptionCardView.m
@@ -16,7 +16,6 @@
         self.vectorArtSize = BTUIKVectorArtSizeRegular;
         self.cornerRadius = 4.0;
         self.innerPadding = 0.0;
-        self.borderWidth = 0.75;
         self.borderColor = UIColor.blackColor;
         self.clipsToBounds = YES;
         self.backgroundColor = [UIColor whiteColor];
@@ -63,7 +62,7 @@
 
 - (void)setPaymentMethodType:(BTDropInPaymentMethodType)paymentMethodType {
     _paymentMethodType = paymentMethodType;
-    self.borderWidth = self.paymentMethodType == BTDropInPaymentMethodTypeApplePay ? 0.0 : self.borderWidth;
+    self.borderWidth = self.paymentMethodType == BTDropInPaymentMethodTypeApplePay ? 0.0 : 0.75;
     self.imageView = [BTUIKViewUtil vectorArtViewForPaymentMethodType:self.paymentMethodType size:self.vectorArtSize];
 }
 


### PR DESCRIPTION
### Summary

On iOS 15, after starting and then cancelling a Card Flow, the black border of the first payment method in the table view disappeared. Seems to be happening since table views re-use cells. For Apple Pay cells, since the border is built into the Apple Pay mark Apple gives us, we set it's `borderWidth` property to zero.

So when re-loading the table view cell after cancelling the Card Flow, a now "PayPal" cell that was formerly an "Apple Pay" cell has 0 border. This fix sets the proper size each time the cell is set, instead of using the first value set.

### Before

https://user-images.githubusercontent.com/35243507/133639969-06d8445a-dd30-4a16-b455-1980023b6c0f.mov

### After

https://user-images.githubusercontent.com/35243507/133640047-d22e767d-23d9-4529-8819-219e60355449.mov

### Checklist

 - [ ] Added a changelog entry

### Authors
@scannillo 
