### PR TITLE
Fix Venmo UITest

### DIFF
--- a/Demo/UITests/BraintreeDropIn_Venmo_UITests.swift
+++ b/Demo/UITests/BraintreeDropIn_Venmo_UITests.swift
@@ -14,7 +14,7 @@ class Venmo_UITests: XCTestCase {
 
         demoApp = XCUIApplication(bundleIdentifier: "com.braintreepayments.DropInDemo")
         demoApp.launchArguments.append("-EnvironmentSandbox")
-        demoApp.launchArguments.append("-ClientToken")
+        demoApp.launchArguments.append("-TokenizationKey")
         demoApp.launch()
 
         waitForElementToAppear(demoApp.buttons["Add Payment Method"])
@@ -28,7 +28,7 @@ class Venmo_UITests: XCTestCase {
         waitForElementToAppear(mockVenmo.buttons["SUCCESS"])
         mockVenmo.buttons["SUCCESS"].tap()
 
-        waitForElementToAppear(demoApp.staticTexts["venmojoe"])
+        waitForElementToAppear(demoApp.staticTexts["@fake-venmo-username"])
     }
 
     func testTokenizeVenmo_whenErrorOccurs_returnsError() {


### PR DESCRIPTION
### Summary of changes

 - These 2 previous PRs (https://github.com/braintree/braintree-ios-drop-in/pull/353 & https://github.com/braintree/braintree-ios-drop-in/pull/352) revealed a failing Venmo UI Tests with the latest XCode 13 beta
 - This PR updates the test to use a `TokenizationKey` for the Venmo UI tests (so we don't have to deal with vaulting issues in the test file) & expects the username from the canned MockVenmo app.

 ### Checklist

 - ~Added a changelog entry~

### Authors
@sshropshire @scannillo 