### PR TITLE
Add Apple Silicon Support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v2
       - name: Use Xcode 12.5
-        run: sudo xcode-select -switch /Applications/Xcode_12.5.app
+        run: sudo xcode-select -switch /Applications/Xcode_12.5.1.app
       - name: Run pod lib lint
         run: pod lib lint
   spm:
@@ -18,14 +18,14 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v2
       - name: Use Xcode 12.5
-        run: sudo xcode-select -switch /Applications/Xcode_12.5.app
+        run: sudo xcode-select -switch /Applications/Xcode_12.5.1.app
       - name: Use current branch
         run: sed -i '' 's/branch = .*/branch = \"'"$GITHUB_HEAD_REF"'\";/' SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
       - name: Run swift package resolve
         run: cd SampleApps/SPMTest && swift package resolve
       - name: Build & archive SPMTest
         run: set -o pipefail && xcodebuild -project 'SampleApps/SPMTest/SPMTest.xcodeproj' -scheme 'SPMTest' clean build archive CODE_SIGNING_ALLOWED=NO | xcpretty
-  cocoapods_xcode_beta:
+  cocoapods_xcode_13:
     name: CocoaPods (Xcode 13)
     runs-on: macOS-11
     steps:
@@ -35,7 +35,7 @@ jobs:
         run: sudo xcode-select -switch /Applications/Xcode_13.0.app
       - name: Run pod lib lint
         run: pod lib lint
-  spm_xcode_beta:
+  spm_xcode_13:
     name: SPM (Xcode 13)
     runs-on: macOS-11
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
 
       - name: Use Xcode 13
-        run: sudo xcode-select -switch  /Applications/Xcode_13.1.a
+        run: sudo xcode-select -switch /Applications/Xcode_13.1.app
 
       - name: Check for unreleased section in changelog
         run: grep "## unreleased" CHANGELOG.md || (echo "::error::No unreleased section found in CHANGELOG"; exit 1)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Use Xcode 12.4
-        run: sudo xcode-select -switch /Applications/Xcode_12.4.app
+      - name: Use Xcode 13
+        run: sudo xcode-select -switch  /Applications/Xcode_13.1.a
 
       - name: Check for unreleased section in changelog
         run: grep "## unreleased" CHANGELOG.md || (echo "::error::No unreleased section found in CHANGELOG"; exit 1)

--- a/BraintreeDropIn.podspec
+++ b/BraintreeDropIn.podspec
@@ -24,18 +24,14 @@ Pod::Spec.new do |s|
   s.source_files  = "Sources/BraintreeDropIn/**/*.{h,m}"
   s.public_header_files = "Sources/BraintreeDropIn/Public/BraintreeDropIn/*.h"
   s.frameworks = "UIKit"
-  s.dependency "Braintree/ApplePay", "~> 5.4", ">=5.4.2"
-  s.dependency "Braintree/Card", "~> 5.4", ">=5.4.2"
-  s.dependency "Braintree/Core", "~> 5.4", ">=5.4.2"
-  s.dependency "Braintree/UnionPay", "~> 5.4", ">=5.4.2"
-  s.dependency "Braintree/PayPal", "~> 5.4", ">=5.4.2"
-  s.dependency "Braintree/ThreeDSecure", "~> 5.4", ">=5.4.2"
-  s.dependency "Braintree/Venmo", "~> 5.4", ">=5.4.2"
+  s.dependency "Braintree/ApplePay", "~> 5.5"
+  s.dependency "Braintree/Card", "~> 5.5"
+  s.dependency "Braintree/Core", "~> 5.5"
+  s.dependency "Braintree/UnionPay", "~> 5.5"
+  s.dependency "Braintree/PayPal", "~> 5.5"
+  s.dependency "Braintree/ThreeDSecure", "~> 5.5"
+  s.dependency "Braintree/Venmo", "~> 5.5"
   s.resource_bundles = {
     "BraintreeDropIn-Localization" => ["Sources/BraintreeDropIn/Resources/*.lproj"] }
 
-  # https://github.com/CocoaPods/CocoaPods/issues/10065#issuecomment-694266259
-  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end
-

--- a/BraintreeDropIn.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BraintreeDropIn.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,12 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "braintree_ios",
+        "package": "Braintree",
         "repositoryURL": "https://github.com/braintree/braintree_ios",
         "state": {
-          "branch": "master",
-          "revision": "ca0cbc19dc767ae5f1c757101437cd7c1e482976",
-          "version": null
+          "branch": null,
+          "revision": "6d57ebe2182ab0e441c8ec359f3c8ba4dc5edb6b",
+          "version": "5.5.0"
         }
       },
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 * iOS 15 - Fix bug where payment method icon border was missing after card flow cancellation
+* Require `braintree_ios` 5.5.0 or higher
+  * Adds support for Apple Silicion development / arm64 simulators
 
 ## 8.2.0 (2021-08-25)
 * iOS 15 Support

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "Braintree", url: "https://github.com/braintree/braintree_ios", .upToNextMajor("5.5.0"))
+        .package(name: "Braintree", url: "https://github.com/braintree/braintree_ios", from: "5.5.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "Braintree", url: "https://github.com/braintree/braintree_ios", from: "5.4.3")
+        .package(name: "Braintree", url: "https://github.com/braintree/braintree_ios", .upToNextMajor("5.5.0"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Release.xcconfig
+++ b/Release.xcconfig
@@ -1,5 +1,0 @@
-// Xcode 12 build system considers arm64 a valid simulator architecture (since it adds support for Apple Silicon which is arm64 based)
-// `xcodebuild` is linking against arm64 based simulators, which aren't available on our intel machines
-// Excluding arm64 in Release builds for simulators allows us to build with Xcode 12 on x86_64 (intel) CPU architecture
-// Workaround to be revisited when Apple Silicon is available
-EXCLUDED_ARCHS[sdk=iphonesimulator*] = arm64


### PR DESCRIPTION
### Summary

 - Braintree v5.5.0 adds arm64 simulator support!

### Changes

- Update Podspec & Package.swift to require `braintree_ios` 5.5.0+
- Remove `EXCLUDED_ARCHS = arm64` workarounds, which are no longer required
- Update to latest GH CI Xcode images where possible

 ### Checklist

 - [X] Added a changelog entry

### Authors
@scannillo 
