### PR TITLE
Update braintree_ios Version to 5.8

### DIFF
--- a/BraintreeDropIn.podspec
+++ b/BraintreeDropIn.podspec
@@ -24,13 +24,13 @@ Pod::Spec.new do |s|
   s.source_files  = "Sources/BraintreeDropIn/**/*.{h,m}"
   s.public_header_files = "Sources/BraintreeDropIn/Public/BraintreeDropIn/*.h"
   s.frameworks = "UIKit"
-  s.dependency "Braintree/ApplePay", "~> 5.6.1"
-  s.dependency "Braintree/Card", "~> 5.6.1"
-  s.dependency "Braintree/Core", "~> 5.6.1"
-  s.dependency "Braintree/UnionPay", "~> 5.6.1"
-  s.dependency "Braintree/PayPal", "~> 5.6.1"
-  s.dependency "Braintree/ThreeDSecure", "~> 5.6.1"
-  s.dependency "Braintree/Venmo", "~> 5.6.1"
+  s.dependency "Braintree/ApplePay", "~> 5.8"
+  s.dependency "Braintree/Card", "~> 5.8"
+  s.dependency "Braintree/Core", "~> 5.8"
+  s.dependency "Braintree/UnionPay", "~> 5.8"
+  s.dependency "Braintree/PayPal", "~> 5.8"
+  s.dependency "Braintree/ThreeDSecure", "~> 5.8"
+  s.dependency "Braintree/Venmo", "~> 5.8"
   s.resource_bundles = {
     "BraintreeDropIn-Localization" => ["Sources/BraintreeDropIn/Resources/*.lproj"] }
 

--- a/BraintreeDropIn.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BraintreeDropIn.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/braintree/braintree_ios",
         "state": {
           "branch": null,
-          "revision": "5cf3fb4dfd60a59763ac582b09839256fa8cb278",
-          "version": "5.6.1"
+          "revision": "914f9c60232d599ed61d52be1ece34b7e700faf6",
+          "version": "5.8.0"
         }
       },
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 * Update Vault Manager inline documentation 
 * Update import statement for transitive dependancies in react native (fixes #365)
+* Require `braintree_ios` 5.8.0 or higher
 
 ## 9.4.0 (2022-01-18)
 * Require `braintree_ios` 5.6.1 or higher

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/braintree/braintree_ios",
         "state": {
           "branch": null,
-          "revision": "9a5da35d658c8c9f224424deaecae82c43bb3857",
-          "version": "5.7.0"
+          "revision": "914f9c60232d599ed61d52be1ece34b7e700faf6",
+          "version": "5.8.0"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/braintree/braintree_ios",
         "state": {
           "branch": null,
-          "revision": "6be5b6ceabe6acf3353a986da272bc604c8cd010",
-          "version": "5.4.2"
+          "revision": "9a5da35d658c8c9f224424deaecae82c43bb3857",
+          "version": "5.7.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "Braintree", url: "https://github.com/braintree/braintree_ios", from: "5.6.1")
+        .package(name: "Braintree", url: "https://github.com/braintree/braintree_ios", from: "5.8.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
### Summary of changes

This updates the braintree_ios framework version to 5.8

 ### Checklist

 - [x] Added a changelog entry

### Authors
- @jaxdesmarais @kaylagalway 
