### PR TITLE
Require `braintree_ios` v5.12.0

### DIFF
--- a/BraintreeDropIn.podspec
+++ b/BraintreeDropIn.podspec
@@ -24,13 +24,13 @@ Pod::Spec.new do |s|
   s.source_files  = "Sources/BraintreeDropIn/**/*.{h,m}"
   s.public_header_files = "Sources/BraintreeDropIn/Public/BraintreeDropIn/*.h"
   s.frameworks = "UIKit"
-  s.dependency "Braintree/ApplePay", "~> 5.9"
-  s.dependency "Braintree/Card", "~> 5.9"
-  s.dependency "Braintree/Core", "~> 5.9"
-  s.dependency "Braintree/UnionPay", "~> 5.9"
-  s.dependency "Braintree/PayPal", "~> 5.9"
-  s.dependency "Braintree/ThreeDSecure", "~> 5.9"
-  s.dependency "Braintree/Venmo", "~> 5.9"
+  s.dependency "Braintree/ApplePay", "~> 5.12"
+  s.dependency "Braintree/Card", "~> 5.12"
+  s.dependency "Braintree/Core", "~> 5.12"
+  s.dependency "Braintree/UnionPay", "~> 5.12"
+  s.dependency "Braintree/PayPal", "~> 5.12"
+  s.dependency "Braintree/ThreeDSecure", "~> 5.12"
+  s.dependency "Braintree/Venmo", "~> 5.12"
   s.resource_bundles = {
     "BraintreeDropIn-Localization" => ["Sources/BraintreeDropIn/Resources/*.lproj"] }
 

--- a/BraintreeDropIn.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BraintreeDropIn.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/braintree/braintree_ios",
         "state": {
           "branch": null,
-          "revision": "59e0ac8add29de6a4476dc949ed86bcdc590cbb2",
-          "version": "5.9.0"
+          "revision": "5013d5bc515ddbe8b50465f10fd7545430d7c86f",
+          "version": "5.12.0"
         }
       },
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## unreleased
 * Remove use of deprecated `setNetworkActivityIndicatorVisible` on iOS 13+ (the network activity indicator was removed from the status bar in iOS 13) (fixes #379)
-* Require `braintree_ios` 5.12.0 or higher
-  * Adds support for iOS 16 and Xcode 14
+* Add support for iOS 16 and Xcode 14
+  * Require `braintree_ios` 5.12.0 or higher
 
 ## 9.6.1 (2022-08-10)
 * Fix bug where `deviceData` on `BTDropInResult` was always returned as `nil`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 * Remove use of deprecated `setNetworkActivityIndicatorVisible` on iOS 13+ (the network activity indicator was removed from the status bar in iOS 13) (fixes #379)
+* Require `braintree_ios` 5.12.0 or higher
+  * Adds support for iOS 16 and Xcode 14
 
 ## 9.6.1 (2022-08-10)
 * Fix bug where `deviceData` on `BTDropInResult` was always returned as `nil`

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/braintree/braintree_ios",
         "state": {
           "branch": null,
-          "revision": "59e0ac8add29de6a4476dc949ed86bcdc590cbb2",
-          "version": "5.9.0"
+          "revision": "5013d5bc515ddbe8b50465f10fd7545430d7c86f",
+          "version": "5.12.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "Braintree", url: "https://github.com/braintree/braintree_ios", from: "5.9.0")
+        .package(name: "Braintree", url: "https://github.com/braintree/braintree_ios", from: "5.12.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
### Summary of changes

 - Require `braintree_ios` [v5.12.0](https://github.com/braintree/braintree_ios/releases/tag/5.12.0) in podspec & package.swift
 - Enables DropIn to offer iOS 16 & Xcode 14 support

 ### Checklist

 - [X] Added a changelog entry

### Authors
@scannillo
