### PR TITLE
Add missing error handling for No Recent Payments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS Drop-in SDK - Release Notes
 
+## unreleased
+* Add explicit error handling for case when `BTDropInResult.mostRecentPaymentMethod(for:)` method fails to fetch any recent payment methods.
+  * Add `BTDropInErrorTypeNoRecentPaymentMethods` error code.
+
 ## 9.7.0 (2022-09-08)
 * Remove use of deprecated `setNetworkActivityIndicatorVisible` on iOS 13+ (the network activity indicator was removed from the status bar in iOS 13) (fixes #379)
 * Add support for iOS 16 and Xcode 14

--- a/Sources/BraintreeDropIn/Models/BTDropInResult.m
+++ b/Sources/BraintreeDropIn/Models/BTDropInResult.m
@@ -133,10 +133,15 @@ static NSUserDefaults *_userDefaults = nil;
                 BTPaymentMethodNonce *paymentMethod = paymentMethodNonces.firstObject;
                 result.paymentMethodType = [BTUIKViewUtil paymentMethodTypeForPaymentInfoType:paymentMethod.type];
                 result.paymentMethod = paymentMethod;
+                completion(result, nil);
+                return;
+            } else {
+                NSError *error = [[NSError alloc] initWithDomain:BTDropInResultErrorDomain
+                                                            code:BTDropInErrorTypeUnknown
+                                                        userInfo:@{NSLocalizedDescriptionKey: @"No recent payment methods found."}];
+                completion(nil, error);
+                return;
             }
-            
-            completion(result, nil);
-            return;
         }];
     }];
 }

--- a/Sources/BraintreeDropIn/Models/BTDropInResult.m
+++ b/Sources/BraintreeDropIn/Models/BTDropInResult.m
@@ -127,19 +127,19 @@ static NSUserDefaults *_userDefaults = nil;
                 completion(nil, error);
                 return;
             }
-            
-            if (paymentMethodNonces.count > 0) {
+
+            if (paymentMethodNonces.count == 0 || paymentMethodNonces == nil) {
+                NSError *error = [[NSError alloc] initWithDomain:BTDropInResultErrorDomain
+                                                            code:BTDropInErrorTypeNoRecentPaymentMethods
+                                                        userInfo:@{NSLocalizedDescriptionKey: @"No recent payment methods found."}];
+                completion(nil, error);
+                return;
+            } else {
                 result = [[BTDropInResult alloc] initWithEnvironment:configuration.environment];
                 BTPaymentMethodNonce *paymentMethod = paymentMethodNonces.firstObject;
                 result.paymentMethodType = [BTUIKViewUtil paymentMethodTypeForPaymentInfoType:paymentMethod.type];
                 result.paymentMethod = paymentMethod;
                 completion(result, nil);
-                return;
-            } else {
-                NSError *error = [[NSError alloc] initWithDomain:BTDropInResultErrorDomain
-                                                            code:BTDropInErrorTypeNoRecentPaymentMethods
-                                                        userInfo:@{NSLocalizedDescriptionKey: @"No recent payment methods found."}];
-                completion(nil, error);
                 return;
             }
         }];

--- a/Sources/BraintreeDropIn/Models/BTDropInResult.m
+++ b/Sources/BraintreeDropIn/Models/BTDropInResult.m
@@ -137,7 +137,7 @@ static NSUserDefaults *_userDefaults = nil;
                 return;
             } else {
                 NSError *error = [[NSError alloc] initWithDomain:BTDropInResultErrorDomain
-                                                            code:BTDropInErrorTypeUnknown
+                                                            code:BTDropInErrorTypeNoRecentPaymentMethods
                                                         userInfo:@{NSLocalizedDescriptionKey: @"No recent payment methods found."}];
                 completion(nil, error);
                 return;

--- a/Sources/BraintreeDropIn/Public/BraintreeDropIn/BTDropInResult.h
+++ b/Sources/BraintreeDropIn/Public/BraintreeDropIn/BTDropInResult.h
@@ -19,6 +19,9 @@ typedef NS_ENUM(NSInteger, BTDropInErrorType) {
 
     /// The client token or tokenization key is invalid
     BTDropInErrorTypeAuthorization,
+    
+    /// No recent payment methods were found
+    BTDropInErrorTypeNoRecentPaymentMethods
 };
 
 @interface BTDropInResult : NSObject

--- a/UnitTests/BTDropInResultTests.swift
+++ b/UnitTests/BTDropInResultTests.swift
@@ -30,13 +30,15 @@ class BTDropInResultTests: XCTestCase {
 
     // MARK: - mostRecentPaymentMethod
 
-    func testMostRecentPaymentMethod_whenCustomerDoesNotHaveVaultedPaymentMethods_returnsNil() {
+    func testMostRecentPaymentMethod_whenCustomerDoesNotHaveVaultedPaymentMethods_returnsError() {
         let mockAPIClient = MockAPIClient(authType: .clientToken)
-
-        let expectation = self.expectation(description: "Calls completion with nil result")
+        mockAPIClient.vaultedPaymentMethodNonces = []
+        
+        let expectation = self.expectation(description: "Calls completion with error")
         BTDropInResult.mostRecentPaymentMethod(for: mockAPIClient) { result, error in
             XCTAssertNil(result)
-            XCTAssertNil(error)
+            XCTAssertEqual(error?.localizedDescription, "No recent payment methods found.")
+            XCTAssertEqual((error! as NSError).code, 2)
             expectation.fulfill()
         }
 


### PR DESCRIPTION
### Background

This GitHub Issue (https://github.com/braintree/braintree-ios-drop-in/issues/383) surfaced a case where we are returning back `(nil, nil)` to the merchant when they call [the `mostRecentPaymentMethod()` function](https://github.com/braintree/braintree-ios-drop-in/blob/89154896389b7d63f06f4808b571821701e1a383/Sources/BraintreeDropIn/Public/BraintreeDropIn/BTDropInResult.h#L66-L67).

Apparently, [our tests were asserting/expecting to return `(nil, nil)`](https://github.com/braintree/braintree-ios-drop-in/blob/89154896389b7d63f06f4808b571821701e1a383/UnitTests/BTDropInResultTests.swift#L38-L39) when no recent payment methods were found). I think this is weird and confusing behavior.

This PR treats this `(nil, nil)` case as a **bug** and fixes it by returning a proper merchant-facing error in the case of an empty vault list returned from the Gateway.

### Summary

- Add `BTDropInErrorTypeNoRecentPaymentMethods` error code
- Return error when no payment method nonces are returned from gateway, but the API call 200s

 ### Checklist

 - [X] Added a changelog entry

### Authors
@scannillo
