### PR TITLE
Disable Bitcode for SPM Test App in Xcode 13 - Fixes CI

### DIFF
--- a/SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
+++ b/SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
@@ -314,6 +314,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 43253H4X22;
+				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
@@ -339,6 +340,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 43253H4X22;
+				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",


### PR DESCRIPTION
### Summary of changes

 - Fix CI for SPM in Xcode 13 by disabling bitcode

 ### Checklist

 - ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jaxdesmarais 
