### PR TITLE
Bump `braintree_ios` to 5.19.0

### DIFF
--- a/BraintreeDropIn.podspec
+++ b/BraintreeDropIn.podspec
@@ -24,13 +24,13 @@ Pod::Spec.new do |s|
   s.source_files  = "Sources/BraintreeDropIn/**/*.{h,m}"
   s.public_header_files = "Sources/BraintreeDropIn/Public/BraintreeDropIn/*.h"
   s.frameworks = "UIKit"
-  s.dependency "Braintree/ApplePay", "~> 5.12"
-  s.dependency "Braintree/Card", "~> 5.12"
-  s.dependency "Braintree/Core", "~> 5.12"
-  s.dependency "Braintree/UnionPay", "~> 5.12"
-  s.dependency "Braintree/PayPal", "~> 5.12"
-  s.dependency "Braintree/ThreeDSecure", "~> 5.12"
-  s.dependency "Braintree/Venmo", "~> 5.12"
+  s.dependency "Braintree/ApplePay", "~> 5.19"
+  s.dependency "Braintree/Card", "~> 5.19"
+  s.dependency "Braintree/Core", "~> 5.19"
+  s.dependency "Braintree/UnionPay", "~> 5.19"
+  s.dependency "Braintree/PayPal", "~> 5.19"
+  s.dependency "Braintree/ThreeDSecure", "~> 5.19"
+  s.dependency "Braintree/Venmo", "~> 5.19"
   s.resource_bundles = {
     "BraintreeDropIn-Localization" => ["Sources/BraintreeDropIn/Resources/*.lproj"] }
 

--- a/BraintreeDropIn.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BraintreeDropIn.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/braintree/braintree_ios",
         "state": {
           "branch": null,
-          "revision": "5013d5bc515ddbe8b50465f10fd7545430d7c86f",
-          "version": "5.12.0"
+          "revision": "d190215f9b219ab5da899b1405ef3b2c8461b983",
+          "version": "5.19.0"
         }
       },
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 * Silence UnionPay related deprecation warnings introduced in `braintree_ios` 5.18.0 and higher.
   * *Note: The UnionPay SMS flow will be removed in BraintreeDropIn v10. UnionPay cards can now be processed as regular cards due to their partnership with Discover.*
+* Require `braintree_ios` 5.19.0 or higher
 
 ## 9.7.0 (2022-09-08)
 * Remove use of deprecated `setNetworkActivityIndicatorVisible` on iOS 13+ (the network activity indicator was removed from the status bar in iOS 13) (fixes #379)

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/braintree/braintree_ios",
         "state": {
           "branch": null,
-          "revision": "5013d5bc515ddbe8b50465f10fd7545430d7c86f",
-          "version": "5.12.0"
+          "revision": "d190215f9b219ab5da899b1405ef3b2c8461b983",
+          "version": "5.19.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "Braintree", url: "https://github.com/braintree/braintree_ios", from: "5.12.0")
+        .package(name: "Braintree", url: "https://github.com/braintree/braintree_ios", from: "5.19.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
### Summary of changes

 - Require braintree_ios [v5.19.0](https://github.com/braintree/braintree_ios/releases/tag/5.19.0) in podspec & Package.swift

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jaxdesmarais 