### PR TITLE
Fixes Title Color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Braintree iOS Drop-in SDK - Release Notes
 
+## unreleased
+* Fixes bug where title color on `BTPaymentSelectionViewController` is set as the default `primaryColor` for the `BTDropInUICustomization(colorScheme:)` (fixes #397)
+
 ## 9.8.0 (2023-01-10)
 * Add explicit error handling for case when `BTDropInResult.mostRecentPaymentMethod(for:)` method fails to fetch any recent payment methods.
   * Add `BTDropInErrorTypeNoRecentPaymentMethods` error code.

--- a/Sources/BraintreeDropIn/BTPaymentSelectionViewController.m
+++ b/Sources/BraintreeDropIn/BTPaymentSelectionViewController.m
@@ -65,6 +65,7 @@ static BOOL _vaultedCardAppearAnalyticSent = NO;
                                                                                action:@selector(cancelButtonPressed:)];
 
     UILabel *titleLabel = [BTUIKAppearance styledNavigationTitleLabel];
+    titleLabel.textColor = [BTUIKAppearance sharedInstance].primaryTextColor;
     titleLabel.text = BTDropInLocalizedString(SELECT_PAYMENT_LABEL);
     titleLabel.textAlignment = NSTextAlignmentCenter;
     titleLabel.numberOfLines = 2;


### PR DESCRIPTION
### Summary of changes

 - Setting the `uiCustomization.navigationBarTitleTextColor` is independent of the color set by `BTDropInUICustomization(colorScheme:)`. This can cause issues if the `navigationBarTitleTextColor` is set similar to the color provided in the `colorScheme`. We should instead use the default `primaryTextColor` to set this `textColor` value instead of using the `navigationBarTitleTextColor` since the background for this is set separately.
 - Fixes #397

### Visuals
| Before | After |
|-----|-----|
|![Simulator Screen Shot - iPhone 14 Pro - 2023-02-27 at 16 48 19](https://user-images.githubusercontent.com/20733831/221879851-cc17649a-f5d1-4fe3-96f3-78f4469161b7.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-02-27 at 16 48 04](https://user-images.githubusercontent.com/20733831/221879985-4b51a245-0047-4185-a9db-7bcdb44eaeee.png)|
|![Simulator Screen Shot - iPhone 14 Pro - 2023-02-27 at 16 48 50](https://user-images.githubusercontent.com/20733831/221880133-c5349548-312f-4dae-bc39-0f55461bf970.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-02-27 at 16 47 49](https://user-images.githubusercontent.com/20733831/221880191-e988a84c-2c95-4de6-951d-65aad1473567.png)|

 ### Checklist

 - [x] Added a changelog entry

### Authors
- @jaxdesmarais 
