### PR TITLE
GitHub Actions Release Update to use MacOS-12 for Reference Docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,16 @@ jobs:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
         run: pod trunk push BraintreeDropIn.podspec
 
+  docs:
+    name: Publish Reference Docs
+    runs-on: macOS-12
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Use Xcode 14
+        run: sudo xcode-select -switch /Applications/Xcode_14.0.app
+
       - name: Publish reference docs
         run: |
           gem install jazzy


### PR DESCRIPTION
### Summary of changes

The release step failed because the latest sourcekitten uses MacOS-12. We were doing the following: sudo xcode-select -switch /Applications/Xcode_14.0.app but have the runner set to macOS-11 which [does not support Xcode 14](https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md#xcode). We will need to be in the [MacOS-12 runner](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#xcode) for Xcode 14 support.

This PR separates the docs publishing into it's own job ([we do something similar in Android release](https://github.com/braintree/braintree_android/blob/master/.github/workflows/release.yml) and the [iOS build](https://github.com/braintree/braintree_ios/blob/master/.github/workflows/build.yml)). This way we can control the macOS version used for this step.

### Checklist

- ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @sshropshire @jaxdesmarais 