### PR TITLE
Fix UnionPay Deprecation Issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Braintree iOS Drop-in SDK - Release Notes
 
+## unreleased
+* Silence UnionPay related deprecation warnings introduced in `braintree_ios` 5.21.0 and higher.
+
 ## 9.8.1 (2023-03-01)
 * Fixes bug where title color on `BTPaymentSelectionViewController` is set as the default `primaryColor` for the `BTDropInUICustomization(colorScheme:)` (fixes #397)
 

--- a/Sources/BraintreeDropIn/BTCardFormViewController.m
+++ b/Sources/BraintreeDropIn/BTCardFormViewController.m
@@ -670,10 +670,7 @@
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
             cardRequest.smsCode = authCode;
             cardRequest.enrollmentID = self.enrollmentID;
-#pragma clang diagnostic pop
-            
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
             [cardClient tokenizeCard:cardRequest options:nil completion:^(BTCardNonce * _Nullable tokenizedCard, NSError * _Nullable error) {
 #pragma clang diagnostic pop
                 dispatch_async(dispatch_get_main_queue(), ^{

--- a/Sources/BraintreeDropIn/BTCardFormViewController.m
+++ b/Sources/BraintreeDropIn/BTCardFormViewController.m
@@ -309,8 +309,11 @@
     BTCardRequest *cardRequest = [[BTCardRequest alloc] initWithCard:card];
     
     if (self.cardCapabilities != nil && self.cardCapabilities.isUnionPay && self.cardCapabilities.isSupported) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         cardRequest.mobileCountryCode = self.mobileCountryCodeField.countryCode;
         cardRequest.mobilePhoneNumber = self.mobilePhoneField.mobileNumber;
+#pragma clang diagnostic pop
     }
     
     return cardRequest;
@@ -663,8 +666,11 @@
                 self.view.userInteractionEnabled = NO;
             });
             
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             cardRequest.smsCode = authCode;
             cardRequest.enrollmentID = self.enrollmentID;
+#pragma clang diagnostic pop
             
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

> Before submitting this PR, note we cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes

Some UnionPay deprecation issues were silenced in https://github.com/braintree/braintree-ios-drop-in/pull/387, but Braintree SDK added new deprecations in version 5.21.0 ( https://github.com/braintree/braintree_ios/pull/950 ). This change silences the new deprecation errors.

 ### Checklist

 - [X] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @mlazari
