### PR TITLE
[DO NOT REVIEW]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,30 +1,6 @@
 name: Build
 on: [pull_request, workflow_dispatch]
 jobs:
-  cocoapods:
-    name: CocoaPods (Xcode 14)
-    runs-on: macOS-12
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v2
-      - name: Use Xcode 14.0
-        run: sudo xcode-select -switch /Applications/Xcode_14.0.app
-      - name: Run pod lib lint
-        run: pod lib lint
-  spm:
-    name: SPM (Xcode 14)
-    runs-on: macOS-12
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v2
-      - name: Use Xcode 14.0
-        run: sudo xcode-select -switch /Applications/Xcode_14.0.app
-      - name: Use current branch
-        run: sed -i '' 's/branch = .*/branch = \"'"$GITHUB_HEAD_REF"'\";/' SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
-      - name: Run swift package resolve
-        run: cd SampleApps/SPMTest && swift package resolve
-      - name: Build & archive SPMTest
-        run: set -o pipefail && xcodebuild -project 'SampleApps/SPMTest/SPMTest.xcodeproj' -scheme 'SPMTest' clean build archive CODE_SIGNING_ALLOWED=NO | xcpretty
   cocoapods_xcode_13:
     name: CocoaPods (Xcode 13)
     runs-on: macOS-12
@@ -35,17 +11,7 @@ jobs:
         run: sudo xcode-select -switch /Applications/Xcode_13.4.app
       - name: Run pod lib lint
         run: pod lib lint
-  spm_xcode_13:
-    name: SPM (Xcode 13)
-    runs-on: macOS-12
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v2
-      - name: Use Xcode 13
-        run: sudo xcode-select -switch /Applications/Xcode_13.4.app
-      - name: Use current branch
-        run: sed -i '' 's/branch = .*/branch = \"'"$GITHUB_HEAD_REF"'\";/' SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
-      - name: Run swift package resolve
-        run: cd SampleApps/SPMTest && swift package resolve
-      - name: Build & archive SPMTest
-        run: set -o pipefail && xcodebuild -project 'SampleApps/SPMTest/SPMTest.xcodeproj' -scheme 'SPMTest' clean build archive CODE_SIGNING_ALLOWED=NO | xcpretty
+      - name: Publish to CocoaPods
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        run: pod trunk push BraintreeDropIn.podspec


### PR DESCRIPTION
### Summary of changes

 - This PR is solely being used to trigger CI to re-run the[ previously failed](https://github.com/braintree/braintree-ios-drop-in/actions/runs/4659214897/jobs/8245830834) `pod trunk push` command for DropIn v 9.8.2
