### PR TITLE
Fix of bug preventing input of further numbers when first digit is '1' in credit card expiry month

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Braintree iOS Drop-in SDK - Release Notes
+## 9.8.3 (2023-04-13)
+* Fixes bug preventing input of digit 1 as first number for credit card expiry month
 
 ## 9.8.2 (2023-04-10)
 * Silence UnionPay related deprecation warnings introduced in `braintree_ios` 5.21.0 and higher.

--- a/Sources/BraintreeDropIn/Models/BTUIKCardExpiryFormat.m
+++ b/Sources/BraintreeDropIn/Models/BTUIKCardExpiryFormat.m
@@ -16,9 +16,17 @@
         return;
     }
 
-    if (*cursorLocation == 1 && s.length == 1 && [s characterAtIndex:0] > '1' && [s characterAtIndex:0] <= '9') {
-        [s insertString:@"0" atIndex:0];
-        *cursorLocation += 1;
+    if (*cursorLocation == 1 && s.length == 1 && [s characterAtIndex:0] >= '0' && [s characterAtIndex:0] != '1' && [s characterAtIndex:0] <= '9') {
+            [s insertString:@"0" atIndex:0];
+            [s insertString:@"/" atIndex:2];
+            *cursorLocation += 2;
+    }
+
+    if (*cursorLocation == 2 && s.length == 2 && [s characterAtIndex:0] == '1') {
+        if ([s characterAtIndex:1] >= '0' && [s characterAtIndex:1] <= '2') {
+           [s insertString:@"/" atIndex:2];
+           *cursorLocation += 1;
+        }
     }
 
     if (self.backspace) {


### PR DESCRIPTION
### Summary of changes

in iOS the expiry month input field for credit card does not accept any other number when the number '1' is entered as first digit. This is due to the `formattedValue` function accepting only first digits bigger than 1. The consequence is that the months **1**1 (November) and **1**2 (December) currently cannot be typed into the field as expiry month.

 ### Checklist

 - [x] Added a changelog entry

### Authors
- Ryan Lin Xiang
