### PR TITLE
Drop Xcode 13 + require Xcode 14.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
   cocoapods:
     name: CocoaPods (Xcode 14)
-    runs-on: macOS-latest
+    runs-on: macOS-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
@@ -13,7 +13,7 @@ jobs:
         run: pod lib lint
   spm:
     name: SPM (Xcode 14)
-    runs-on: macOS-latest
+    runs-on: macOS-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,46 +3,22 @@ on: [pull_request, workflow_dispatch]
 jobs:
   cocoapods:
     name: CocoaPods (Xcode 14)
-    runs-on: macOS-12
+    runs-on: macOS-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
-      - name: Use Xcode 14.0
-        run: sudo xcode-select -switch /Applications/Xcode_14.0.app
+      - name: Use Xcode 14.1
+        run: sudo xcode-select -switch /Applications/Xcode_14.1.app
       - name: Run pod lib lint
         run: pod lib lint
   spm:
     name: SPM (Xcode 14)
-    runs-on: macOS-12
+    runs-on: macOS-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
-      - name: Use Xcode 14.0
-        run: sudo xcode-select -switch /Applications/Xcode_14.0.app
-      - name: Use current branch
-        run: sed -i '' 's/branch = .*/branch = \"'"$GITHUB_HEAD_REF"'\";/' SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
-      - name: Run swift package resolve
-        run: cd SampleApps/SPMTest && swift package resolve
-      - name: Build & archive SPMTest
-        run: set -o pipefail && xcodebuild -project 'SampleApps/SPMTest/SPMTest.xcodeproj' -scheme 'SPMTest' clean build archive CODE_SIGNING_ALLOWED=NO | xcpretty
-  cocoapods_xcode_13:
-    name: CocoaPods (Xcode 13)
-    runs-on: macOS-12
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v2
-      - name: Use Xcode 13
-        run: sudo xcode-select -switch /Applications/Xcode_13.4.app
-      - name: Run pod lib lint
-        run: pod lib lint
-  spm_xcode_13:
-    name: SPM (Xcode 13)
-    runs-on: macOS-12
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v2
-      - name: Use Xcode 13
-        run: sudo xcode-select -switch /Applications/Xcode_13.4.app
+      - name: Use Xcode 14.1
+        run: sudo xcode-select -switch /Applications/Xcode_14.1.app
       - name: Use current branch
         run: sed -i '' 's/branch = .*/branch = \"'"$GITHUB_HEAD_REF"'\";/' SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
       - name: Run swift package resolve

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,15 +8,15 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: macOS-11
+    runs-on: macOS-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
-      - name: Use Xcode 13
-        run: sudo xcode-select -switch /Applications/Xcode_13.1.app
+      - name: Use Xcode 14.1
+        run: sudo xcode-select -switch /Applications/Xcode_14.1.app
 
       - name: Check for unreleased section in changelog
         run: grep "## unreleased" CHANGELOG.md || (echo "::error::No unreleased section found in CHANGELOG"; exit 1)
@@ -64,13 +64,13 @@ jobs:
 
   docs:
     name: Publish Reference Docs
-    runs-on: macOS-12
+    runs-on: macOS-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
 
-      - name: Use Xcode 14
-        run: sudo xcode-select -switch /Applications/Xcode_14.0.app
+      - name: Use Xcode 14.1
+        run: sudo xcode-select -switch /Applications/Xcode_14.1.app
 
       - name: Publish reference docs
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: macOS-latest
+    runs-on: macOS-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
@@ -64,7 +64,7 @@ jobs:
 
   docs:
     name: Publish Reference Docs
-    runs-on: macOS-latest
+    runs-on: macOS-12
     steps:
       - name: Check out repository
         uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,21 +3,21 @@ on: pull_request
 jobs:
   unit_test_job:
     name: Unit
-    runs-on: macOS-12
+    runs-on: macOS-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Use Xcode 14
-        run: sudo xcode-select -switch /Applications/Xcode_14.0.app
+      - name: Use Xcode 14.1
+        run: sudo xcode-select -switch /Applications/Xcode_14.1.app
       - name: Run Unit Tests
         run: set -o pipefail && xcodebuild -workspace 'BraintreeDropIn.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 11,platform=iOS Simulator'  test  | xcpretty
   ui_test_job:
     name: UI
-    runs-on: macOS-12
+    runs-on: macOS-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Use Xcode 14
-        run: sudo xcode-select -switch /Applications/Xcode_14.0.app
+      - name: Use Xcode 14.1
+        run: sudo xcode-select -switch /Applications/Xcode_14.1.app
       - name: Run UI Tests
         run: set -o pipefail && xcodebuild -workspace 'BraintreeDropIn.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UITests' -destination 'name=iPhone 11,platform=iOS Simulator'  test  | xcpretty

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ on: pull_request
 jobs:
   unit_test_job:
     name: Unit
-    runs-on: macOS-latest
+    runs-on: macOS-12
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -13,7 +13,7 @@ jobs:
         run: set -o pipefail && xcodebuild -workspace 'BraintreeDropIn.xcworkspace' -sdk 'iphonesimulator' -configuration 'Debug' -scheme 'UnitTests' -destination 'name=iPhone 11,platform=iOS Simulator'  test  | xcpretty
   ui_test_job:
     name: UI
-    runs-on: macOS-latest
+    runs-on: macOS-12
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/BraintreeDropIn.podspec
+++ b/BraintreeDropIn.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.platform         = :ios, "12.0"
   s.requires_arc     = true
   s.compiler_flags = "-Wall -Werror -Wextra"
-  s.swift_version = "5.1"
+  s.swift_version = "5.7"
 
   s.source_files  = "Sources/BraintreeDropIn/**/*.{h,m}"
   s.public_header_files = "Sources/BraintreeDropIn/Public/BraintreeDropIn/*.h"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Braintree iOS Drop-in SDK - Release Notes
 
+## unreleased
+* Require Xcode 14.1+ and Swift 5.7.1+ (per [App Store requirements](https://developer.apple.com/news/?id=jd9wcyov#:~:text=Starting%20April%2025%2C%202023%2C%20iOS,on%20the%20Mac%20App%20Store))
+
 ## 9.8.2 (2023-04-10)
 * Silence UnionPay related deprecation warnings introduced in `braintree_ios` 5.21.0 and higher.
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Welcome to Braintree's Drop-in SDK for iOS!
 
 ![Drop-in light theme](Images/client-sdk-ios-series-light.png "Drop-in light theme")
 
-**The Braintree iOS Drop-in SDK permits a deployment target of iOS 12.0 or higher.** It requires Xcode 12+ and Swift 5.1+.
+**The Braintree iOS Drop-in SDK permits a deployment target of iOS 12.0 or higher.** It requires Xcode 14.1+ and Swift 5.7.1+.
 
 ## Table of Contents
 


### PR DESCRIPTION
### Summary of changes

 - On April 25, 2023 Apple is mandating that apps submitted to the App Store must be built with Xcode 14.1 or higher (Swift 5.7.1+)
    - [See news article](https://developer.apple.com/news/?id=jd9wcyov#:~:text=Starting%20April%2025%2C%202023%2C%20iOS,on%20the%20Mac%20App%20Store)
- Update all GitHub workflows with new Xcode requirement
- Remove Xcode 13 support from GitHub workflows
- Update Package.swift with new Swift requirement
- Update podspec with new Swift requirement
- Add README and CHANGELOG entry with this change

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @jaxdesmarais 