### PR TITLE
Rename `master` to `main` cleanup 

### DIFF
--- a/BraintreeDropIn.podspec
+++ b/BraintreeDropIn.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   DESC
   s.homepage         = "https://developer.paypal.com/braintree/docs"
   s.documentation_url = "https://developer.paypal.com/braintree/docs/start/hello-client/ios/v5"
-  s.screenshots      = ["https://github.com/braintree/braintree-ios-drop-in/raw/master/Images/client-sdk-ios-series-light.png", "https://github.com/braintree/braintree-ios-drop-in/raw/master/Images/client-sdk-ios-series-dark.png"]
+  s.screenshots      = ["https://github.com/braintree/braintree-ios-drop-in/raw/main/Images/client-sdk-ios-series-light.png", "https://github.com/braintree/braintree-ios-drop-in/raw/main/Images/client-sdk-ios-series-dark.png"]
   s.license          = "MIT"
   s.author           = { "Braintree" => "team-bt-sdk@paypal.com" }
   s.source           = { :git => "https://github.com/braintree/braintree-ios-drop-in.git", :tag => s.version.to_s }

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -31,7 +31,7 @@ Example: importing an internal header file
 #import "BTUIKAppearance.h"
 ```
 
-For more information on how header imports work for each package manager, see the [DEVELOPMENT guide](https://github.com/braintree/braintree_ios/blob/master/DEVELOPMENT.md#importing-header-files) in Braintree iOS.
+For more information on how header imports work for each package manager, see the [DEVELOPMENT guide](https://github.com/braintree/braintree_ios/blob/main/DEVELOPMENT.md#importing-header-files) in Braintree iOS.
 
 ## Releasing
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ pod 'BraintreeDropIn'
 ```
 Then run `pod install`.
 
-See our [`Podspec`](https://github.com/braintree/braintree-ios-drop-in/blob/master/BraintreeDropIn.podspec) for more information.
+See our [`Podspec`](https://github.com/braintree/braintree-ios-drop-in/blob/main/BraintreeDropIn.podspec) for more information.
 
 *Note:* If you are using version 8.x.x of the Braintree Drop-in iOS SDK in Xcode 12, you may see the warning `The iOS Simulator deployment target is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.0.99`. This will not prevent your app from compiling. This is a [CocoaPods issue](https://github.com/CocoaPods/CocoaPods/issues/7314) with a known workaround.
 
@@ -167,7 +167,7 @@ BTDropInResult.mostRecentPaymentMethod(forClientToken: authorization) { result, 
 
 ### Localization
 
-Drop-in is currently localized for [22 languages](https://github.com/braintree/braintree-ios-drop-in/tree/master/Sources/BraintreeDropIn/Resources).
+Drop-in is currently localized for [22 languages](https://github.com/braintree/braintree-ios-drop-in/tree/main/Sources/BraintreeDropIn/Resources).
 
 ### Color Schemes
 
@@ -257,4 +257,4 @@ Here are a few ways to get in touch:
 
 ## License
 
-The Braintree iOS Drop-in SDK is open source and available under the MIT license. See the [LICENSE](https://github.com/braintree/braintree-ios-drop-in/blob/master/LICENSE) file for more info.
+The Braintree iOS Drop-in SDK is open source and available under the MIT license. See the [LICENSE](https://github.com/braintree/braintree-ios-drop-in/blob/main/LICENSE) file for more info.

--- a/SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
+++ b/SampleApps/SPMTest/SPMTest.xcodeproj/project.pbxproj
@@ -386,7 +386,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/braintree/braintree-ios-drop-in.git";
 			requirement = {
-				branch = master;
+				branch = main;
 				kind = branch;
 			};
 		};


### PR DESCRIPTION
### Summary of changes

We renamed our default branch from `master` to `main`. This PR:
- Updates our internal SPM sample apps to specify `main`
- Update GitHub repo URL links in README, DEVELOPMENT.md, and Podspec 

### Checklist

- ~Added a changelog entry~

### Authors
@scannillo @jaxdesmarais 