### PR TITLE
Modal Status Bar Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 * Require Xcode 14.1+ and Swift 5.7.1+ (per [App Store requirements](https://developer.apple.com/news/?id=jd9wcyov#:~:text=Starting%20April%2025%2C%202023%2C%20iOS,on%20the%20Mac%20App%20Store))
 * Add California Privacy Laws notice of collection to credit card form
+* Fix bug where presenting the Drop-in from a modal screen without a `modalPresentationStyle` does not display the status bar when both device and Drop-in are in light mode (fixes #419)
 
 ## 9.8.2 (2023-04-10)
 * Silence UnionPay related deprecation warnings introduced in `braintree_ios` 5.21.0 and higher.

--- a/Sources/BraintreeDropIn/BTDropInController.m
+++ b/Sources/BraintreeDropIn/BTDropInController.m
@@ -303,6 +303,8 @@
     vd.supportedCardTypes = self.displayCardTypes;
     vd.delegate = self;
     UINavigationController* navController = [[UINavigationController alloc] initWithRootViewController:vd];
+    [navController setModalPresentationCapturesStatusBarAppearance: true];
+
     if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad) {
         navController.modalPresentationStyle = UIModalPresentationPageSheet;
     } else {


### PR DESCRIPTION
### Summary of changes

 - Fix bug where presenting the Drop-in from a modal screen without a `modalPresentationStyle` does not display the status bar when both device and Drop-in are in light mode (fixes #419)

#### Testing
- All flows have been tested to ensure this does not impact other setups
- Additional testing has been done with alternate modal presentation styles to ensure the status bar continues to be shown as expected

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @jaxdesmarais 
