### PR TITLE
Property to Hide Card Logos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## unreleased
 * Require Xcode 14.1+ and Swift 5.7.1+ (per [App Store requirements](https://developer.apple.com/news/?id=jd9wcyov#:~:text=Starting%20April%2025%2C%202023%2C%20iOS,on%20the%20Mac%20App%20Store))
 * Add California Privacy Laws notice of collection to credit card form
-* Add `BTDropInRequest.self.cardLogosDisabled` to hide card logos on the Drop-in card form view if desired
+* Add `BTDropInRequest.self.cardLogosDisabled` to hide card logos on the credit card form if desired
 
 ## 9.8.2 (2023-04-10)
 * Silence UnionPay related deprecation warnings introduced in `braintree_ios` 5.21.0 and higher.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## unreleased
 * Require Xcode 14.1+ and Swift 5.7.1+ (per [App Store requirements](https://developer.apple.com/news/?id=jd9wcyov#:~:text=Starting%20April%2025%2C%202023%2C%20iOS,on%20the%20Mac%20App%20Store))
 * Add California Privacy Laws notice of collection to credit card form
-* Add `BTDropInRequest.self.cardLogosDisabled` to hide card logos on the credit card form if desired
+* Add `BTDropInRequest.cardLogosDisabled` to hide card logos on the credit card form if desired
 
 ## 9.8.2 (2023-04-10)
 * Silence UnionPay related deprecation warnings introduced in `braintree_ios` 5.21.0 and higher.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 * Require Xcode 14.1+ and Swift 5.7.1+ (per [App Store requirements](https://developer.apple.com/news/?id=jd9wcyov#:~:text=Starting%20April%2025%2C%202023%2C%20iOS,on%20the%20Mac%20App%20Store))
 * Add California Privacy Laws notice of collection to credit card form
+* Add `BTDropInRequest.self.cardLogosDisabled` to hide card logos on the Drop-in card form view if desired
 
 ## 9.8.2 (2023-04-10)
 * Silence UnionPay related deprecation warnings introduced in `braintree_ios` 5.21.0 and higher.

--- a/Demo/Application/DemoDropInViewController.swift
+++ b/Demo/Application/DemoDropInViewController.swift
@@ -44,6 +44,7 @@ class DemoDropInViewController: DemoBaseViewController, DemoDropInViewDelegate {
         
         dropInRequest.paypalDisabled = DemoSettings.paypalDisabled
         dropInRequest.cardDisabled = ProcessInfo.processInfo.arguments.contains("-CardDisabled")
+        dropInRequest.cardLogosDisabled = ProcessInfo.processInfo.arguments.contains("-CardLogosDisabled")
         dropInRequest.shouldMaskSecurityCode = DemoSettings.maskSecurityCode
         dropInRequest.cardholderNameSetting = DemoSettings.cardholderNameSetting
         dropInRequest.vaultCard = DemoSettings.vaultCardSetting

--- a/Demo/UITests/BraintreeDropIn_UITests.swift
+++ b/Demo/UITests/BraintreeDropIn_UITests.swift
@@ -180,6 +180,61 @@ class BraintreeDropIn_CardDisabled_UITests: XCTestCase {
     }
 }
 
+class BraintreeDropIn_CardLogosDisabled_UITests: XCTestCase {
+
+    var app: XCUIApplication!
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchArguments.append("-EnvironmentSandbox")
+        app.launchArguments.append("-TokenizationKey")
+        app.launchArguments.append("-CardLogosDisabled")
+        app.launch()
+        sleep(1)
+        waitForElementToBeHittable(app.buttons["Add Payment Method"])
+        app.buttons["Add Payment Method"].tap()
+    }
+
+    func testDropIn_cardLogosDisabledOption_hidesCardLogos() {
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        app.staticTexts["Credit or Debit Card"].tap()
+
+        let elementsQuery = app.scrollViews.otherElements
+        let cardLogoImages = elementsQuery.images.element.exists
+
+        XCTAssertFalse(cardLogoImages)
+    }
+}
+
+class BraintreeDropIn_CardLogosEnabled_UITests: XCTestCase {
+
+    var app: XCUIApplication!
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchArguments.append("-EnvironmentSandbox")
+        app.launchArguments.append("-TokenizationKey")
+        app.launch()
+        sleep(1)
+        waitForElementToBeHittable(app.buttons["Add Payment Method"])
+        app.buttons["Add Payment Method"].tap()
+    }
+
+    func testDropIn_cardLogosEnabledOption_showsCardLogos() {
+        waitForElementToBeHittable(app.staticTexts["Credit or Debit Card"])
+        app.staticTexts["Credit or Debit Card"].tap()
+
+        let elementsQuery = app.scrollViews.otherElements
+        let cardLogoImages = elementsQuery.images.element.exists
+
+        XCTAssertTrue(cardLogoImages)
+    }
+}
+
 class BraintreeDropIn_CardForm_RequestOptions_UITests: XCTestCase {
 
     var app: XCUIApplication!

--- a/Sources/BraintreeDropIn/BTCardFormViewController.m
+++ b/Sources/BraintreeDropIn/BTCardFormViewController.m
@@ -234,12 +234,15 @@
     self.cardNumberFooter.layoutMargins = UIEdgeInsetsMake(0, [BTUIKAppearance verticalFormSpace], 0, [BTUIKAppearance verticalFormSpace]);
     self.cardNumberFooter.layoutMarginsRelativeArrangement = true;
     [self.stackView addArrangedSubview:self.cardNumberFooter];
-    self.cardList = [BTUIKCardListLabel new];
-    self.cardList.translatesAutoresizingMaskIntoConstraints = NO;
-    self.cardList.availablePaymentOptions = self.supportedCardTypes;
-    [self.cardNumberFooter addArrangedSubview:self.cardList];
-    [BTDropInUIUtilities addSpacerToStackView:self.cardNumberFooter beforeView:self.cardList size: [BTUIKAppearance horizontalFormContentPadding]];
-    
+
+    if (!self.dropInRequest.cardLogosDisabled) {
+        self.cardList = [BTUIKCardListLabel new];
+        self.cardList.translatesAutoresizingMaskIntoConstraints = NO;
+        self.cardList.availablePaymentOptions = self.supportedCardTypes;
+        [self.cardNumberFooter addArrangedSubview:self.cardList];
+        [BTDropInUIUtilities addSpacerToStackView:self.cardNumberFooter beforeView:self.cardList size: [BTUIKAppearance horizontalFormContentPadding]];
+    }
+
     NSUInteger indexOfCardNumberField = [self.stackView.arrangedSubviews indexOfObject:self.cardNumberField];
     [self.stackView insertArrangedSubview:self.cardNumberFooter atIndex:(indexOfCardNumberField + 1)];
     

--- a/Sources/BraintreeDropIn/Models/BTDropInRequest.m
+++ b/Sources/BraintreeDropIn/Models/BTDropInRequest.m
@@ -25,6 +25,7 @@
     request.paypalDisabled = self.paypalDisabled;
     request.venmoDisabled = self.venmoDisabled;
     request.cardDisabled = self.cardDisabled;
+    request.cardLogosDisabled = self.cardLogosDisabled;
     request.threeDSecureRequest = self.threeDSecureRequest;
     request.cardholderNameSetting = self.cardholderNameSetting;
     request.shouldMaskSecurityCode = self.shouldMaskSecurityCode;

--- a/Sources/BraintreeDropIn/Public/BraintreeDropIn/BTDropInRequest.h
+++ b/Sources/BraintreeDropIn/Public/BraintreeDropIn/BTDropInRequest.h
@@ -40,6 +40,9 @@ typedef NS_ENUM(NSInteger, BTFormFieldSetting) {
 /// Defaults to false. Set to true to hide the Card option even if enabled for your account.
 @property (nonatomic, assign) BOOL cardDisabled;
 
+/// Defaults to false. Set to true to hide all card logos for your account.
+@property (nonatomic, assign) BOOL cardLogosDisabled;
+
 /// Optional: Enable 3DS verification and specify options and additional information.
 ///
 /// Note: To encourage 3DS 2.0 flows, set `billingAddress`, `amount`, `email`, `mobilePhone` for best results.

--- a/UnitTests/BTDropInRequestTests.m
+++ b/UnitTests/BTDropInRequestTests.m
@@ -45,6 +45,7 @@
     originalRequest.paypalDisabled = YES;
     originalRequest.venmoDisabled = YES;
     originalRequest.cardDisabled = YES;
+    originalRequest.cardLogosDisabled = YES;
     originalRequest.threeDSecureRequest = threeDSecureRequest;
     originalRequest.cardholderNameSetting = BTFormFieldOptional;
     originalRequest.shouldMaskSecurityCode = YES;
@@ -60,6 +61,7 @@
     XCTAssertEqual(originalRequest.paypalDisabled, copiedRequest.paypalDisabled);
     XCTAssertEqual(originalRequest.venmoDisabled, copiedRequest.venmoDisabled);
     XCTAssertEqual(originalRequest.cardDisabled, copiedRequest.cardDisabled);
+    XCTAssertEqual(originalRequest.cardLogosDisabled, copiedRequest.cardLogosDisabled);
     XCTAssertEqual(originalRequest.cardholderNameSetting, copiedRequest.cardholderNameSetting);
     XCTAssertEqual(originalRequest.shouldMaskSecurityCode, copiedRequest.shouldMaskSecurityCode);
     XCTAssertEqual(originalRequest.vaultManager, copiedRequest.vaultManager);


### PR DESCRIPTION
### Summary of changes

 - Add `BTDropInRequest.cardLogosDisabled` to hide card logos on the credit card form if desired
     - This is a merchant requested feature to resolve a live issue
     - Android PR: https://github.com/braintree/braintree-android-drop-in/pull/426

### Visuals
| Without `cardLogosDisabled` |  With `cardLogosDisabled` |
|-----|-----|
|![Simulator Screenshot - iPhone 14 - 2023-08-04 at 13 19 41](https://github.com/braintree/braintree-ios-drop-in/assets/20733831/ecd0da20-1509-4743-985a-0d160c234b95)|![Simulator Screenshot - iPhone 14 - 2023-08-04 at 13 19 03](https://github.com/braintree/braintree-ios-drop-in/assets/20733831/16369c6f-b8d6-4a65-83aa-0154ddaef6b2)|

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @jaxdesmarais 
