### PR TITLE
Bump `braintree_ios` to 5.23.0

### DIFF
--- a/BraintreeDropIn.podspec
+++ b/BraintreeDropIn.podspec
@@ -24,13 +24,13 @@ Pod::Spec.new do |s|
   s.source_files  = "Sources/BraintreeDropIn/**/*.{h,m}"
   s.public_header_files = "Sources/BraintreeDropIn/Public/BraintreeDropIn/*.h"
   s.frameworks = "UIKit"
-  s.dependency "Braintree/ApplePay", "~> 5.19"
-  s.dependency "Braintree/Card", "~> 5.19"
-  s.dependency "Braintree/Core", "~> 5.19"
-  s.dependency "Braintree/UnionPay", "~> 5.19"
-  s.dependency "Braintree/PayPal", "~> 5.19"
-  s.dependency "Braintree/ThreeDSecure", "~> 5.19"
-  s.dependency "Braintree/Venmo", "~> 5.19"
+  s.dependency "Braintree/ApplePay", "~> 5.23"
+  s.dependency "Braintree/Card", "~> 5.23"
+  s.dependency "Braintree/Core", "~> 5.23"
+  s.dependency "Braintree/UnionPay", "~> 5.23"
+  s.dependency "Braintree/PayPal", "~> 5.23"
+  s.dependency "Braintree/ThreeDSecure", "~> 5.23"
+  s.dependency "Braintree/Venmo", "~> 5.23"
   s.resource_bundles = {
     "BraintreeDropIn-Localization" => ["Sources/BraintreeDropIn/Resources/*.lproj"] }
 

--- a/BraintreeDropIn.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BraintreeDropIn.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/braintree/braintree_ios",
         "state": {
           "branch": null,
-          "revision": "d190215f9b219ab5da899b1405ef3b2c8461b983",
-          "version": "5.19.0"
+          "revision": "3924f5ea0295087081e7e637fbf1333361e7054b",
+          "version": "5.23.0"
         }
       },
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Braintree iOS Drop-in SDK - Release Notes
 
+## unreleased
+* Require `braintree_ios` 5.23.0
+
 ## 9.9.0 (2023-08-10)
 * Require Xcode 14.1+ and Swift 5.7.1+ (per [App Store requirements](https://developer.apple.com/news/?id=jd9wcyov#:~:text=Starting%20April%2025%2C%202023%2C%20iOS,on%20the%20Mac%20App%20Store))
 * Add California Privacy Laws notice of collection to credit card form

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/braintree/braintree_ios",
         "state": {
           "branch": null,
-          "revision": "d190215f9b219ab5da899b1405ef3b2c8461b983",
-          "version": "5.19.0"
+          "revision": "3924f5ea0295087081e7e637fbf1333361e7054b",
+          "version": "5.23.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "Braintree", url: "https://github.com/braintree/braintree_ios", from: "5.19.0")
+        .package(name: "Braintree", url: "https://github.com/braintree/braintree_ios", from: "5.23.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
### Summary of changes

 - Require `braintree_ios` [v5.23.0](https://github.com/braintree/braintree_ios/releases/tag/5.23.0) in podspec & Package.swift

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @jaxdesmarais 
