### PR TITLE
Update to Use Macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 * Require `braintree_ios` 5.23.0
+* Update to use macros to avoid compile time errors (fixes #421)
 
 ## 9.9.0 (2023-08-10)
 * Require Xcode 14.1+ and Swift 5.7.1+ (per [App Store requirements](https://developer.apple.com/news/?id=jd9wcyov#:~:text=Starting%20April%2025%2C%202023%2C%20iOS,on%20the%20Mac%20App%20Store))

--- a/Sources/BraintreeDropIn/BTDropInUICustomization.m
+++ b/Sources/BraintreeDropIn/BTDropInUICustomization.m
@@ -19,7 +19,11 @@
                 _placeholderTextColor = UIColor.lightGrayColor;
                 _lineColor = [UIColor btuik_colorFromHex:@"BFBFBF" alpha:1.0];
                 _blurStyle = UIBlurEffectStyleExtraLight;
+                #if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_13_0
                 _activityIndicatorViewStyle = UIActivityIndicatorViewStyleGray;
+                #else
+                _activityIndicatorViewStyle = UIActivityIndicatorViewStyleMedium;
+                #endif
                 _overlayColor = [UIColor btuik_colorFromHex:@"000000" alpha:0.5];
                 _tintColor = [UIColor btuik_colorFromHex:@"2489F6" alpha:1.0];
                 _disabledColor = UIColor.lightGrayColor;
@@ -38,7 +42,11 @@
                 _placeholderTextColor = [UIColor btuik_colorFromHex:@"8E8E8E" alpha:1.0];
                 _lineColor = [UIColor btuik_colorFromHex:@"666666" alpha:1.0];
                 _blurStyle = UIBlurEffectStyleDark;
+                #if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_13_0
                 _activityIndicatorViewStyle = UIActivityIndicatorViewStyleWhite;
+                #else
+                _activityIndicatorViewStyle = UIActivityIndicatorViewStyleMedium;
+                #endif
                 _overlayColor = [UIColor btuik_colorFromHex:@"000000" alpha:0.5];
                 _tintColor = [UIColor btuik_colorFromHex:@"2489F6" alpha:1.0];
                 _disabledColor = UIColor.lightGrayColor;

--- a/Sources/BraintreeDropIn/BTPaymentSelectionViewController.m
+++ b/Sources/BraintreeDropIn/BTPaymentSelectionViewController.m
@@ -186,14 +186,14 @@ static BOOL _vaultedCardAppearAnalyticSent = NO;
     }
     
     #if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_13_0
-        // The network activity indicator no longer appears on status bars for iOS 13+
-        [UIApplication.sharedApplication setNetworkActivityIndicatorVisible:YES];
+    // The network activity indicator no longer appears on status bars for iOS 13+
+    [UIApplication.sharedApplication setNetworkActivityIndicatorVisible:YES];
     #endif
 
     [self.apiClient fetchPaymentMethodNonces:YES completion:^(NSArray<BTPaymentMethodNonce *> *paymentMethodNonces, NSError *error) {
         #if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_13_0
-            // The network activity indicator no longer appears on status bars for iOS 13+
-            [UIApplication.sharedApplication setNetworkActivityIndicatorVisible:NO];
+        // The network activity indicator no longer appears on status bars for iOS 13+
+        [UIApplication.sharedApplication setNetworkActivityIndicatorVisible:NO];
         #endif
         
         if (error) {

--- a/Sources/BraintreeDropIn/BTPaymentSelectionViewController.m
+++ b/Sources/BraintreeDropIn/BTPaymentSelectionViewController.m
@@ -185,17 +185,16 @@ static BOOL _vaultedCardAppearAnalyticSent = NO;
         return;
     }
     
-    if (@available(iOS 13, *)) {
+    #if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_13_0
         // The network activity indicator no longer appears on status bars for iOS 13+
-    } else {
         [UIApplication.sharedApplication setNetworkActivityIndicatorVisible:YES];
-    }
+    #endif
+
     [self.apiClient fetchPaymentMethodNonces:YES completion:^(NSArray<BTPaymentMethodNonce *> *paymentMethodNonces, NSError *error) {
-        if (@available(iOS 13, *)) {
+        #if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_13_0
             // The network activity indicator no longer appears on status bars for iOS 13+
-        } else {
             [UIApplication.sharedApplication setNetworkActivityIndicatorVisible:NO];
-        }
+        #endif
         
         if (error) {
             // no action

--- a/Sources/BraintreeDropIn/BTVaultManagementViewController.m
+++ b/Sources/BraintreeDropIn/BTVaultManagementViewController.m
@@ -98,14 +98,14 @@ NSString *const BTGraphQLDeletePaymentMethodFromSingleUseToken = @""
     }
 
     #if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_13_0
-        // The network activity indicator no longer appears on status bars for iOS 13+
-        [UIApplication.sharedApplication setNetworkActivityIndicatorVisible:YES];
+    // The network activity indicator no longer appears on status bars for iOS 13+
+    [UIApplication.sharedApplication setNetworkActivityIndicatorVisible:YES];
     #endif
 
     [self.apiClient fetchPaymentMethodNonces:YES completion:^(NSArray<BTPaymentMethodNonce *> *paymentMethodNonces, NSError *error) {
         #if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_13_0
-            // The network activity indicator no longer appears on status bars for iOS 13+
-            [UIApplication.sharedApplication setNetworkActivityIndicatorVisible:NO];
+        // The network activity indicator no longer appears on status bars for iOS 13+
+        [UIApplication.sharedApplication setNetworkActivityIndicatorVisible:NO];
         #endif
 
         if (error) {

--- a/Sources/BraintreeDropIn/BTVaultManagementViewController.m
+++ b/Sources/BraintreeDropIn/BTVaultManagementViewController.m
@@ -97,18 +97,16 @@ NSString *const BTGraphQLDeletePaymentMethodFromSingleUseToken = @""
         return;
     }
 
-    if (@available(iOS 13, *)) {
+    #if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_13_0
         // The network activity indicator no longer appears on status bars for iOS 13+
-    } else {
         [UIApplication.sharedApplication setNetworkActivityIndicatorVisible:YES];
-    }
+    #endif
 
     [self.apiClient fetchPaymentMethodNonces:YES completion:^(NSArray<BTPaymentMethodNonce *> *paymentMethodNonces, NSError *error) {
-        if (@available(iOS 13, *)) {
+        #if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_13_0
             // The network activity indicator no longer appears on status bars for iOS 13+
-        } else {
             [UIApplication.sharedApplication setNetworkActivityIndicatorVisible:NO];
-        }
+        #endif
 
         if (error) {
             // no action

--- a/Sources/BraintreeDropIn/Helpers/BTUIKViewUtil.m
+++ b/Sources/BraintreeDropIn/Helpers/BTUIKViewUtil.m
@@ -257,19 +257,19 @@
 }
 
 + (BOOL)isOrientationLandscape NS_EXTENSION_UNAVAILABLE("Uses APIs (i.e UIApplication.sharedApplication) not available for use in App Extensions.") {
-    if (@available(iOS 13, *)) {
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_13_0
         return UIInterfaceOrientationIsLandscape([self activeWindowScene].interfaceOrientation);
-    } else {
+    #else
         return UIInterfaceOrientationIsLandscape(UIApplication.sharedApplication.statusBarOrientation);
-    }
+    #endif
 }
 
 + (CGFloat)statusBarHeight NS_EXTENSION_UNAVAILABLE("Uses APIs (i.e UIApplication.sharedApplication) not available for use in App Extensions.") {
-    if (@available(iOS 13, *)) {
+    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_13_0
         return CGRectGetHeight([self activeWindowScene].statusBarManager.statusBarFrame);
-    } else {
+    #else
         return CGRectGetHeight(UIApplication.sharedApplication.statusBarFrame);
-    }
+    #endif
 }
 
 @end

--- a/Sources/BraintreeDropIn/Helpers/BTUIKViewUtil.m
+++ b/Sources/BraintreeDropIn/Helpers/BTUIKViewUtil.m
@@ -258,17 +258,17 @@
 
 + (BOOL)isOrientationLandscape NS_EXTENSION_UNAVAILABLE("Uses APIs (i.e UIApplication.sharedApplication) not available for use in App Extensions.") {
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_13_0
-        return UIInterfaceOrientationIsLandscape([self activeWindowScene].interfaceOrientation);
+    return UIInterfaceOrientationIsLandscape([self activeWindowScene].interfaceOrientation);
     #else
-        return UIInterfaceOrientationIsLandscape(UIApplication.sharedApplication.statusBarOrientation);
+    return UIInterfaceOrientationIsLandscape(UIApplication.sharedApplication.statusBarOrientation);
     #endif
 }
 
 + (CGFloat)statusBarHeight NS_EXTENSION_UNAVAILABLE("Uses APIs (i.e UIApplication.sharedApplication) not available for use in App Extensions.") {
     #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_13_0
-        return CGRectGetHeight([self activeWindowScene].statusBarManager.statusBarFrame);
+    return CGRectGetHeight([self activeWindowScene].statusBarManager.statusBarFrame);
     #else
-        return CGRectGetHeight(UIApplication.sharedApplication.statusBarFrame);
+    return CGRectGetHeight(UIApplication.sharedApplication.statusBarFrame);
     #endif
 }
 


### PR DESCRIPTION
### Summary of changes

 - Previously using `if/else` blocks would cause the code to still be compiled when unavailable at runtime. This causes error for merchants with certain build settings. Switching the macros allows the compiler to exclude this code under this condition as it's no longer included if not needed at compile time.
 - Fixes #421 

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @jaxdesmarais