### PR TITLE
Fix Navigation Bar Bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Braintree iOS Drop-in SDK - Release Notes
 
+## unreleased
+* Fix bug where setting global navigation bar overrides the payment selection screen (fixes #435)
+* Allow overriding navigation bar color and text via `BTDropInUICustomization.barBackgroundColor` and `BTDropInUICustomization.primaryTextColor`
+
 ## 9.10.0 (2023-09-06)
 * Require `braintree_ios` 5.23.0
 * Update to use macros to avoid compile time errors (fixes #421)

--- a/Sources/BraintreeDropIn/BTPaymentSelectionViewController.m
+++ b/Sources/BraintreeDropIn/BTPaymentSelectionViewController.m
@@ -74,6 +74,7 @@ static BOOL _vaultedCardAppearAnalyticSent = NO;
     self.navigationItem.titleView = titleLabel;
 
     self.navigationController.navigationBar.barTintColor = [BTUIKAppearance sharedInstance].barBackgroundColor;
+    self.navigationController.navigationBar.translucent = NO;
     if (@available(iOS 15, *)) {
         UINavigationBarAppearance *appearance = [[UINavigationBarAppearance alloc]init];
         appearance.backgroundColor = [BTUIKAppearance sharedInstance].barBackgroundColor;

--- a/Sources/BraintreeDropIn/BTPaymentSelectionViewController.m
+++ b/Sources/BraintreeDropIn/BTPaymentSelectionViewController.m
@@ -73,6 +73,16 @@ static BOOL _vaultedCardAppearAnalyticSent = NO;
     [titleLabel sizeToFit];
     self.navigationItem.titleView = titleLabel;
 
+    self.navigationController.navigationBar.barTintColor = [BTUIKAppearance sharedInstance].barBackgroundColor;
+    if (@available(iOS 15, *)) {
+        UINavigationBarAppearance *appearance = [[UINavigationBarAppearance alloc]init];
+        appearance.backgroundColor = [BTUIKAppearance sharedInstance].barBackgroundColor;
+
+        self.navigationController.navigationBar.standardAppearance = appearance;
+        self.navigationController.navigationBar.scrollEdgeAppearance = self.navigationController.navigationBar.standardAppearance;
+    }
+
+    [self.navigationController.navigationBar setTitleTextAttributes:@{ NSForegroundColorAttributeName: [BTUIKAppearance sharedInstance].primaryTextColor }];
     [self.navigationController.navigationBar setBackgroundImage:[UIImage new] forBarMetrics:UIBarMetricsDefault]; // make nav bar clear
     self.view.backgroundColor = UIColor.clearColor;
 


### PR DESCRIPTION
### Summary of changes

 - Fix bug where setting global navigation bar overrides the payment selection screen (fixes #435)
 - Allow overriding navigation bar color and text via `BTDropInUICustomization.barBackgroundColor` and `BTDropInUICustomization.primaryTextColor`
     - This allows the payment selection screen to be customized in the same way as the other views

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @jaxdesmarais 
