### PR TITLE
Bump `braintree_ios` to  5.25.0

### DIFF
--- a/BraintreeDropIn.podspec
+++ b/BraintreeDropIn.podspec
@@ -24,13 +24,13 @@ Pod::Spec.new do |s|
   s.source_files  = "Sources/BraintreeDropIn/**/*.{h,m}"
   s.public_header_files = "Sources/BraintreeDropIn/Public/BraintreeDropIn/*.h"
   s.frameworks = "UIKit"
-  s.dependency "Braintree/ApplePay", "~> 5.23"
-  s.dependency "Braintree/Card", "~> 5.23"
-  s.dependency "Braintree/Core", "~> 5.23"
-  s.dependency "Braintree/UnionPay", "~> 5.23"
-  s.dependency "Braintree/PayPal", "~> 5.23"
-  s.dependency "Braintree/ThreeDSecure", "~> 5.23"
-  s.dependency "Braintree/Venmo", "~> 5.23"
+  s.dependency "Braintree/ApplePay", "~> 5.25"
+  s.dependency "Braintree/Card", "~> 5.25"
+  s.dependency "Braintree/Core", "~> 5.25"
+  s.dependency "Braintree/UnionPay", "~> 5.25"
+  s.dependency "Braintree/PayPal", "~> 5.25"
+  s.dependency "Braintree/ThreeDSecure", "~> 5.25"
+  s.dependency "Braintree/Venmo", "~> 5.25"
   s.resource_bundles = {
     "BraintreeDropIn-Localization" => ["Sources/BraintreeDropIn/Resources/*.lproj"],
     "BraintreeDropIn_PrivacyInfo" => ["Sources/BraintreeDropIn/PrivacyInfo.xcprivacy"]

--- a/BraintreeDropIn.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/BraintreeDropIn.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/BraintreeDropIn.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/BraintreeDropIn.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IDEDidComputeMac32BitWarning</key>
-	<true/>
-</dict>
-</plist>

--- a/BraintreeDropIn.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BraintreeDropIn.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,25 +1,23 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "Braintree",
-        "repositoryURL": "https://github.com/braintree/braintree_ios",
-        "state": {
-          "branch": null,
-          "revision": "3924f5ea0295087081e7e637fbf1333361e7054b",
-          "version": "5.23.0"
-        }
-      },
-      {
-        "package": "InAppSettingsKit",
-        "repositoryURL": "https://github.com/futuretap/InAppSettingsKit.git",
-        "state": {
-          "branch": null,
-          "revision": "71e03ebad8462618f96c575c86d2e9220f880676",
-          "version": "3.3.2"
-        }
+  "pins" : [
+    {
+      "identity" : "braintree_ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/braintree/braintree_ios",
+      "state" : {
+        "revision" : "619e78a9ab9423be4871baf406546c22573086cf",
+        "version" : "5.25.0"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "inappsettingskit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/futuretap/InAppSettingsKit.git",
+      "state" : {
+        "revision" : "71e03ebad8462618f96c575c86d2e9220f880676",
+        "version" : "3.3.2"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 * Require Xcode 15.0+ and Swift 5.9+ (per [App Store requirements](https://developer.apple.com/news/?id=khzvxn8a))
 * [Meets Apple's new Privacy Update requirements](https://developer.apple.com/news/?id=3d8a9yyh)
+* Require `braintree_ios` 5.25.0
 
 ## 9.11.0 (2024-02-06)
 * Add Slovak language support

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,16 +1,14 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "Braintree",
-        "repositoryURL": "https://github.com/braintree/braintree_ios",
-        "state": {
-          "branch": null,
-          "revision": "3924f5ea0295087081e7e637fbf1333361e7054b",
-          "version": "5.23.0"
-        }
+  "pins" : [
+    {
+      "identity" : "braintree_ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/braintree/braintree_ios",
+      "state" : {
+        "revision" : "619e78a9ab9423be4871baf406546c22573086cf",
+        "version" : "5.25.0"
       }
-    ]
-  },
-  "version": 1
+    }
+  ],
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "Braintree", url: "https://github.com/braintree/braintree_ios", from: "5.23.0")
+        .package(name: "Braintree", url: "https://github.com/braintree/braintree_ios", from: "5.25.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
### Summary of changes

 - Modify Package.swift and Podspec files to point to BT iOS 5.25.0
 - Update CHANGELOG

 ### Checklist

 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @KunJeongPark @agedd 
