### PR TITLE
Remove Deprecated `UIGraphicsBeginImageContextWithOptions` API Usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Braintree iOS Drop-in SDK - Release Notes
 
+## unreleased
+* Remove deprecated `UIGraphicsBeginImageContextWithOptions` API usage (fixes #446)
+
 ## 9.12.0 (2024-04-15)
 * Require Xcode 15.0+ and Swift 5.9+ (per [App Store requirements](https://developer.apple.com/news/?id=khzvxn8a))
 * [Meets Apple's new Privacy Update requirements](https://developer.apple.com/news/?id=3d8a9yyh)

--- a/Sources/BraintreeDropIn/Vector Art/BTUIKVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/BTUIKVectorArtView.h
@@ -13,10 +13,4 @@
 /// of the artwork.
 @property (nonatomic, assign) CGSize artDimensions;
 
-/// Returns a UIImage of the artwork
-///
-/// @param size the size of the desired UIImage
-/// @return A UIImage of of the artwork
-- (UIImage *)imageOfSize:(CGSize)size;
-
 @end

--- a/Sources/BraintreeDropIn/Vector Art/BTUIKVectorArtView.m
+++ b/Sources/BraintreeDropIn/Vector Art/BTUIKVectorArtView.m
@@ -21,12 +21,4 @@
     // Subclass overrides this
 }
 
-- (UIImage *)imageOfSize:(CGSize)size {
-    UIGraphicsBeginImageContextWithOptions(size, NO, 0);
-    [self drawRect:CGRectMake(0, 0, size.width, size.height)];
-    UIImage *img = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
-    return img;
-}
-
 @end


### PR DESCRIPTION
### Summary of changes

 - Fixes https://github.com/braintree/braintree-ios-drop-in/issues/446

#### Visuals
No changes to the UI so images look the same, which is expected
| Before | After |
|-----|-----|
|![Simulator Screenshot - iPhone 15 - 2024-04-16 at 10 19 40](https://github.com/braintree/braintree-ios-drop-in/assets/20733831/5edadf4a-8734-4445-b8d6-eff3c3f47906)|![Simulator Screenshot - iPhone 15 - 2024-04-16 at 10 19 40](https://github.com/braintree/braintree-ios-drop-in/assets/20733831/5edadf4a-8734-4445-b8d6-eff3c3f47906)|
|![Simulator Screenshot - iPhone 15 - 2024-04-16 at 10 54 34](https://github.com/braintree/braintree-ios-drop-in/assets/20733831/85eba2d6-9a76-44aa-a43b-8d17cd847c50)|![Simulator Screenshot - iPhone 15 - 2024-04-16 at 10 59 40](https://github.com/braintree/braintree-ios-drop-in/assets/20733831/7ce3357b-42a9-4299-840d-0bc2eff8a42d)|

 ### Checklist

 - [x] Added a changelog entry

### Authors

- @jaxdesmarais 
