### PR TITLE
Missing Reason for PaymentInfo Collection in PrivacyInfo.xcprivacyInfo File

### DIFF
--- a/Sources/BraintreeDropIn/PrivacyInfo.xcprivacy
+++ b/Sources/BraintreeDropIn/PrivacyInfo.xcprivacy
@@ -24,7 +24,7 @@
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>
 			<array>
-				<string></string>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
### Summary of changes

 - [Githhub issue](https://github.com/braintree/braintree-ios-drop-in/issues/450) reported that the reason for paymentInfo collection is missing in the privacy manifest file

 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @KunJeongPark 
