### PR TITLE
Added deprecation tags

### DIFF
--- a/BraintreeDropIn.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BraintreeDropIn.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,23 @@
+{
+  "pins" : [
+    {
+      "identity" : "braintree_ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/braintree/braintree_ios",
+      "state" : {
+        "revision" : "1d4fcd9343bab98759482b4da0b1b6bdaa122b31",
+        "version" : "5.27.0"
+      }
+    },
+    {
+      "identity" : "inappsettingskit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/futuretap/InAppSettingsKit.git",
+      "state" : {
+        "revision" : "4a25f3e1ecdbf3759bdcd0891ae30b0e622f6eff",
+        "version" : "3.7.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Braintree iOS Drop-in SDK - Release Notes
 
+## unreleased
+* Added deprecation tags to all Drop-In classes
+
 ## 9.13.0 (2024-08-26)
 * Updated expiring pinned vendor SSL certificates
 * Require `braintree_ios` 5.26.0

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "Braintree", url: "https://github.com/braintree/braintree_ios", from: "5.26.0")
+        .package(url: "https://github.com/braintree/braintree_ios", from: "5.26.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -22,15 +22,15 @@ let package = Package(
         .target(
             name: "BraintreeDropIn",
             dependencies: [
-                .product(name: "BraintreeApplePay", package: "Braintree"),
-                .product(name: "BraintreeCard", package: "Braintree"),
-                .product(name: "BraintreeCore", package: "Braintree"),
-                .product(name: "BraintreePaymentFlow", package: "Braintree"),
-                .product(name: "BraintreePayPal", package: "Braintree"),
-                .product(name: "BraintreeThreeDSecure", package: "Braintree"),
-                .product(name: "BraintreeUnionPay", package: "Braintree"),
-                .product(name: "BraintreeVenmo", package: "Braintree"),
-                .product(name: "PayPalDataCollector", package: "Braintree")
+                .product(name: "BraintreeApplePay", package: "braintree_ios"),
+                .product(name: "BraintreeCard", package: "braintree_ios"),
+                .product(name: "BraintreeCore", package: "braintree_ios"),
+                .product(name: "BraintreePaymentFlow", package: "braintree_ios"),
+                .product(name: "BraintreePayPal", package: "braintree_ios"),
+                .product(name: "BraintreeThreeDSecure", package: "braintree_ios"),
+                .product(name: "BraintreeUnionPay", package: "braintree_ios"),
+                .product(name: "BraintreeVenmo", package: "braintree_ios"),
+                .product(name: "PayPalDataCollector", package: "braintree_ios")
             ],
             exclude: ["Info.plist"],
             resources: [.copy("PrivacyInfo.xcprivacy")],

--- a/Sources/BraintreeDropIn/BTAPIClient_Internal_Category.h
+++ b/Sources/BraintreeDropIn/BTAPIClient_Internal_Category.h
@@ -10,6 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class BTHTTP;
 @class BTAnalyticsService;
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTAPIClient (Internal)
 
 @property (nonatomic, copy, nullable) NSString *tokenizationKey;

--- a/Sources/BraintreeDropIn/BTCardFormViewController.h
+++ b/Sources/BraintreeDropIn/BTCardFormViewController.h
@@ -13,6 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class BTCardRequest, BTCardCapabilities, BTPaymentMethodNonce;
 @protocol BTCardFormViewControllerDelegate, BTDropInControllerDelegate;
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 /// Contains form elements for entering card information.
 @interface BTCardFormViewController : BTDropInBaseViewController <UITextFieldDelegate, BTUIKFormFieldDelegate, BTUIKCardNumberFormFieldDelegate>
 

--- a/Sources/BraintreeDropIn/BTDropInBaseViewController.h
+++ b/Sources/BraintreeDropIn/BTDropInBaseViewController.h
@@ -4,6 +4,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class BTAPIClient, BTDropInRequest, BTConfiguration;
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 /// The base UIViewController for the sub UIViewControllers using in Drop-In
 @interface BTDropInBaseViewController : UIViewController 
 

--- a/Sources/BraintreeDropIn/BTDropInUIUtilities.h
+++ b/Sources/BraintreeDropIn/BTDropInUIUtilities.h
@@ -1,5 +1,6 @@
 #import <UIKit/UIKit.h>
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTDropInUIUtilities : NSObject
 
 + (UIView *)addSpacerToStackView:(UIStackView*)stackView beforeView:(UIView*)view size:(float)size;

--- a/Sources/BraintreeDropIn/BTPaymentMethodNonce+DropIn.h
+++ b/Sources/BraintreeDropIn/BTPaymentMethodNonce+DropIn.h
@@ -9,6 +9,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTPaymentMethodNonce (DropIn)
 
 @property (nonatomic, copy, readonly) NSString *paymentDescription;

--- a/Sources/BraintreeDropIn/BTPaymentSelectionViewController.h
+++ b/Sources/BraintreeDropIn/BTPaymentSelectionViewController.h
@@ -11,6 +11,7 @@
 @class BTPaymentMethodNonce;
 @protocol BTPaymentSelectionViewControllerDelegate, BTDropInControllerDelegate, BTAppSwitchDelegate, BTViewControllerPresentingDelegate;
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 /// @class A UIViewController that displays vaulted payment methods for a customer and available payment options
 @interface BTPaymentSelectionViewController : BTDropInBaseViewController <UITableViewDataSource, UITableViewDelegate>
 

--- a/Sources/BraintreeDropIn/BTUIKBarButtonItem_Internal_Declaration.h
+++ b/Sources/BraintreeDropIn/BTUIKBarButtonItem_Internal_Declaration.h
@@ -1,5 +1,6 @@
 #import <UIKit/UIKit.h>
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKBarButtonItem : UIBarButtonItem
 @property (nonatomic) BOOL bold;
 @end

--- a/Sources/BraintreeDropIn/BTVaultManagementViewController.h
+++ b/Sources/BraintreeDropIn/BTVaultManagementViewController.h
@@ -6,6 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class BTPaymentMethodNonce;
 @protocol BTDropInControllerDelegate;
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 /// Contains form elements for editing vaulted payment methods.
 @interface BTVaultManagementViewController : BTDropInBaseViewController <UITableViewDataSource, UITableViewDelegate>
 

--- a/Sources/BraintreeDropIn/Components/BTUIKBarButtonItem.h
+++ b/Sources/BraintreeDropIn/Components/BTUIKBarButtonItem.h
@@ -1,5 +1,6 @@
 #import <UIKit/UIKit.h>
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKBarButtonItem : UIBarButtonItem
 @property (nonatomic) BOOL bold;
 @end

--- a/Sources/BraintreeDropIn/Components/BTUIKCardListLabel.h
+++ b/Sources/BraintreeDropIn/Components/BTUIKCardListLabel.h
@@ -1,6 +1,7 @@
 #import <UIKit/UIKit.h>
 #import <BraintreeDropIn/BTDropInPaymentMethodType.h>
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 /// @class A UILabel that contains images representing multiple BTDropInPaymentMethodType's
 @interface BTUIKCardListLabel : UILabel
 

--- a/Sources/BraintreeDropIn/Components/BTUIKCardNumberFormField.h
+++ b/Sources/BraintreeDropIn/Components/BTUIKCardNumberFormField.h
@@ -3,6 +3,7 @@
 
 @protocol BTUIKCardNumberFormFieldDelegate;
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 /// @class Form field to collect a card number.
 @interface BTUIKCardNumberFormField : BTUIKFormField
 

--- a/Sources/BraintreeDropIn/Components/BTUIKCardholderNameFormField.h
+++ b/Sources/BraintreeDropIn/Components/BTUIKCardholderNameFormField.h
@@ -1,5 +1,6 @@
 #import "BTUIKFormField.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKCardholderNameFormField : BTUIKFormField
 
 /// The cardholder name

--- a/Sources/BraintreeDropIn/Components/BTUIKCollectionReusableView.h
+++ b/Sources/BraintreeDropIn/Components/BTUIKCollectionReusableView.h
@@ -1,5 +1,6 @@
 #import <UIKit/UIKit.h>
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKCollectionReusableView : UICollectionReusableView
 
 @property (nonatomic, strong) UILabel* label;

--- a/Sources/BraintreeDropIn/Components/BTUIKExpiryFormField.h
+++ b/Sources/BraintreeDropIn/Components/BTUIKExpiryFormField.h
@@ -1,5 +1,6 @@
 #import "BTUIKFormField.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 /// @class Form field to collect an expiration date.
 @interface BTUIKExpiryFormField : BTUIKFormField
 /// The expiration month

--- a/Sources/BraintreeDropIn/Components/BTUIKFormField.h
+++ b/Sources/BraintreeDropIn/Components/BTUIKFormField.h
@@ -3,6 +3,7 @@
 
 @protocol BTUIKFormFieldDelegate;
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 /// @class A UIView containing a BTUIKTextField and other elements to be displayed as a form field. This class is meant to be extended but can be used as is for other generic form fields.
 @interface BTUIKFormField : UIView <UITextFieldDelegate, UIKeyInput>
 

--- a/Sources/BraintreeDropIn/Components/BTUIKInputAccessoryToolbar.h
+++ b/Sources/BraintreeDropIn/Components/BTUIKInputAccessoryToolbar.h
@@ -1,5 +1,6 @@
 #import <UIKit/UIKit.h>
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 /// @class Creates a toolbar with that can be used as an input accessory view.
 @interface BTUIKInputAccessoryToolbar : UIToolbar
 

--- a/Sources/BraintreeDropIn/Components/BTUIKMobileCountryCodeFormField.h
+++ b/Sources/BraintreeDropIn/Components/BTUIKMobileCountryCodeFormField.h
@@ -1,5 +1,6 @@
 #import "BTUIKFormField.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 /// @class Form field to collect a mobile country code
 @interface BTUIKMobileCountryCodeFormField : BTUIKFormField
 

--- a/Sources/BraintreeDropIn/Components/BTUIKMobileNumberFormField.h
+++ b/Sources/BraintreeDropIn/Components/BTUIKMobileNumberFormField.h
@@ -1,5 +1,6 @@
 #import "BTUIKFormField.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 /// @class Form field to collect a mobile phone number
 @interface BTUIKMobileNumberFormField : BTUIKFormField
 

--- a/Sources/BraintreeDropIn/Components/BTUIKPaymentOptionCardView.h
+++ b/Sources/BraintreeDropIn/Components/BTUIKPaymentOptionCardView.h
@@ -2,6 +2,7 @@
 #import <BraintreeDropIn/BTDropInPaymentMethodType.h>
 #import "BTUIKViewUtil.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 /// @class A UIView containing the BTUIKVectorArtView for a BTDropInPaymentMethodType within a light border.
 @interface BTUIKPaymentOptionCardView : UIView
 

--- a/Sources/BraintreeDropIn/Components/BTUIKPostalCodeFormField.h
+++ b/Sources/BraintreeDropIn/Components/BTUIKPostalCodeFormField.h
@@ -1,5 +1,6 @@
 #import "BTUIKFormField.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 /// @class Form field to collect a postal code
 @interface BTUIKPostalCodeFormField : BTUIKFormField
 

--- a/Sources/BraintreeDropIn/Components/BTUIKSecurityCodeFormField.h
+++ b/Sources/BraintreeDropIn/Components/BTUIKSecurityCodeFormField.h
@@ -1,5 +1,6 @@
 #import "BTUIKFormField.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 /// @class Form field to collect a mobile country code
 @interface BTUIKSecurityCodeFormField : BTUIKFormField
 

--- a/Sources/BraintreeDropIn/Components/BTUIKSwitchFormField.h
+++ b/Sources/BraintreeDropIn/Components/BTUIKSwitchFormField.h
@@ -2,6 +2,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKSwitchFormField : UIView
 
 - (instancetype)initWithTitle:(NSString *)title;

--- a/Sources/BraintreeDropIn/Components/BTUIKTextField.h
+++ b/Sources/BraintreeDropIn/Components/BTUIKTextField.h
@@ -2,6 +2,7 @@
 
 @protocol BTUIKTextFieldEditDelegate;
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 /// @class A specialized text field that provides more granular callbacks than a standard
 /// UITextField as the user edits text
 @interface BTUIKTextField : UITextField

--- a/Sources/BraintreeDropIn/Custom Views/BTDropInPaymentSelectionCell.h
+++ b/Sources/BraintreeDropIn/Custom Views/BTDropInPaymentSelectionCell.h
@@ -2,6 +2,7 @@
 #import "BTUIKPaymentOptionCardView.h"
 #import <BraintreeDropIn/BTDropInPaymentMethodType.h>
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTDropInPaymentSelectionCell : UITableViewCell
 
 @property (nonatomic, strong) UILabel* label;

--- a/Sources/BraintreeDropIn/Custom Views/BTEnrollmentVerificationViewController.h
+++ b/Sources/BraintreeDropIn/Custom Views/BTEnrollmentVerificationViewController.h
@@ -2,6 +2,7 @@
 #import "BTDropInBaseViewController.h"
 #import "BTUIKFormField.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 // NEXT_MAJOR_VERSION: - Remove BTEnrollmentVerificationViewController.
 @interface BTEnrollmentVerificationViewController : BTDropInBaseViewController <UITextFieldDelegate, BTUIKFormFieldDelegate>
 typedef void (^BTEnrollmentHandler)(NSString* authCode, BOOL resendSms);

--- a/Sources/BraintreeDropIn/Custom Views/BTPaymentSelectionHeaderView.h
+++ b/Sources/BraintreeDropIn/Custom Views/BTPaymentSelectionHeaderView.h
@@ -4,6 +4,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol BTPaymentSelectionHeaderViewDelegate;
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 /// Header view displayed in the payment selection table view when there are multiple sections,
 /// specifically, "RECENT" for vaulted payment methods and "OTHER" for options to add new payment method.
 @interface BTPaymentSelectionHeaderView : UITableViewHeaderFooterView

--- a/Sources/BraintreeDropIn/Custom Views/BTUIPaymentMethodCollectionViewCell.h
+++ b/Sources/BraintreeDropIn/Custom Views/BTUIPaymentMethodCollectionViewCell.h
@@ -8,6 +8,7 @@
 
 @class BTUIKPaymentOptionCardView;
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIPaymentMethodCollectionViewCell : UICollectionViewCell
 @property (nonatomic, strong) BTUIKPaymentOptionCardView* paymentOptionCardView;
 @property (nonatomic, strong) UILabel* titleLabel;

--- a/Sources/BraintreeDropIn/Custom Views/BTVaultedPaymentMethodsTableViewCell.h
+++ b/Sources/BraintreeDropIn/Custom Views/BTVaultedPaymentMethodsTableViewCell.h
@@ -5,6 +5,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol BTVaultedPaymentMethodsTableViewCellDelegate;
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 /// Table view cell that displays vaulted payment methods on the payment method selection sheet.
 /// This cell contains a horizontally scrolling collection view.
 @interface BTVaultedPaymentMethodsTableViewCell : UITableViewCell

--- a/Sources/BraintreeDropIn/Helpers/BTConfiguration+DropIn.h
+++ b/Sources/BraintreeDropIn/Helpers/BTConfiguration+DropIn.h
@@ -6,6 +6,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTConfiguration (DropIn)
 
 @property (nonatomic, strong, readonly) NSArray<NSString *> *supportedCardTypes;

--- a/Sources/BraintreeDropIn/Helpers/BTUIKAppearance.h
+++ b/Sources/BraintreeDropIn/Helpers/BTUIKAppearance.h
@@ -1,6 +1,7 @@
 #import <BraintreeDropIn/BTDropInUICustomization.h>
 #import <UIKit/UIKit.h>
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKAppearance : NSObject
 
 typedef NS_ENUM(NSInteger, BTUIKColorScheme) {

--- a/Sources/BraintreeDropIn/Helpers/BTUIKViewUtil.h
+++ b/Sources/BraintreeDropIn/Helpers/BTUIKViewUtil.h
@@ -13,6 +13,7 @@ typedef NS_ENUM(NSInteger, BTUIKVectorArtSize) {
     BTUIKVectorArtSizeLarge,
 };
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 /// @class Utilities used by other views to get localized strings, a BTDropInPaymentMethodType or artwork
 @interface BTUIKViewUtil : NSObject
 

--- a/Sources/BraintreeDropIn/Helpers/UIColor+BTUIK.h
+++ b/Sources/BraintreeDropIn/Helpers/UIColor+BTUIK.h
@@ -1,5 +1,6 @@
 #import <UIKit/UIKit.h>
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface UIColor (BTUIK)
 
 /// Color with bytes and alpha

--- a/Sources/BraintreeDropIn/Helpers/UIFont+BTUIK.h
+++ b/Sources/BraintreeDropIn/Helpers/UIFont+BTUIK.h
@@ -2,6 +2,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface UIFont (BTUIK)
 
 + (UIFont *)bodyFontForFontFamily:(NSString * _Nullable)fontFamily useStaticSize:(BOOL)useStaticSize;

--- a/Sources/BraintreeDropIn/Localization/BTDropInLocalization_Internal.h
+++ b/Sources/BraintreeDropIn/Localization/BTDropInLocalization_Internal.h
@@ -3,6 +3,7 @@
 
 #define BTDropInLocalizedString(KEY) [BTDropInLocalization KEY]
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTDropInLocalization (Internal)
 
 #pragma mark Localization helpers

--- a/Sources/BraintreeDropIn/Models/BTDropInResult_Internal.h
+++ b/Sources/BraintreeDropIn/Models/BTDropInResult_Internal.h
@@ -2,6 +2,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTDropInResult (Internal)
 
 // Exposed for testing

--- a/Sources/BraintreeDropIn/Models/BTUIKCardExpirationValidator.h
+++ b/Sources/BraintreeDropIn/Models/BTUIKCardExpirationValidator.h
@@ -2,6 +2,7 @@
 
 #define kBTUIKCardExpirationValidatorFarFutureYears 20
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKCardExpirationValidator : NSObject
 
 + (BOOL)month:(NSUInteger)month year:(NSUInteger)year validForDate:(NSDate *)date;

--- a/Sources/BraintreeDropIn/Models/BTUIKCardExpiryFormat.h
+++ b/Sources/BraintreeDropIn/Models/BTUIKCardExpiryFormat.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKCardExpiryFormat : NSObject
 @property (nonatomic, copy) NSString *value;
 @property (nonatomic, assign) NSUInteger cursorLocation;

--- a/Sources/BraintreeDropIn/Models/BTUIKCardType.h
+++ b/Sources/BraintreeDropIn/Models/BTUIKCardType.h
@@ -1,6 +1,7 @@
 #import <UIKit/UIKit.h>
 #import "BTDropInLocalization_Internal.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 /// Immutable card type
 @interface BTUIKCardType : NSObject
 

--- a/Sources/BraintreeDropIn/Models/BTUIKUtil.h
+++ b/Sources/BraintreeDropIn/Models/BTUIKUtil.h
@@ -1,5 +1,6 @@
 #import <UIKit/UIKit.h>
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKUtil : NSObject
 
 /// Checks if a card number is Luhn valid

--- a/Sources/BraintreeDropIn/Public/BraintreeDropIn/BTDropInController.h
+++ b/Sources/BraintreeDropIn/Public/BraintreeDropIn/BTDropInController.h
@@ -7,6 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class BTPaymentMethodNonce;
 @protocol BTAppSwitchDelegate, BTViewControllerPresentingDelegate;
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 /// The primary UIViewController for Drop-In. BTDropInController will manage the other UIViewControllers and return a BTDropInResult.
 @interface BTDropInController : UIViewController <UIToolbarDelegate, UIViewControllerTransitioningDelegate>
 

--- a/Sources/BraintreeDropIn/Public/BraintreeDropIn/BTDropInLocalization.h
+++ b/Sources/BraintreeDropIn/Public/BraintreeDropIn/BTDropInLocalization.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTDropInLocalization : NSObject
 
 /// Sets custom translation locales for the Drop-In UI

--- a/Sources/BraintreeDropIn/Public/BraintreeDropIn/BTDropInRequest.h
+++ b/Sources/BraintreeDropIn/Public/BraintreeDropIn/BTDropInRequest.h
@@ -20,6 +20,7 @@ typedef NS_ENUM(NSInteger, BTFormFieldSetting) {
     BTFormFieldRequired
 };
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTDropInRequest : NSObject <NSCopying>
 
 /// Optional: Specify the options for the PayPal flow using either BTPayPalCheckoutRequest or BTPayPalVaultRequest. If not present, a default vault flow will be used.

--- a/Sources/BraintreeDropIn/Public/BraintreeDropIn/BTDropInResult.h
+++ b/Sources/BraintreeDropIn/Public/BraintreeDropIn/BTDropInResult.h
@@ -24,6 +24,7 @@ typedef NS_ENUM(NSInteger, BTDropInErrorType) {
     BTDropInErrorTypeNoRecentPaymentMethods
 };
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTDropInResult : NSObject
 
 /// True if the modal was dismissed without selecting a payment method

--- a/Sources/BraintreeDropIn/Public/BraintreeDropIn/BTDropInUICustomization.h
+++ b/Sources/BraintreeDropIn/Public/BraintreeDropIn/BTDropInUICustomization.h
@@ -12,6 +12,7 @@ typedef NS_ENUM(NSInteger, BTDropInColorScheme) {
     BTDropInColorSchemeDynamic API_AVAILABLE(ios(13.0))
 };
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 /**
  Options for customizing Braintree Drop-in's user interface.
  */

--- a/Sources/BraintreeDropIn/Vector Art/BTUIKAmExVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/BTUIKAmExVectorArtView.h
@@ -1,5 +1,6 @@
 #import "BTUIKCardVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKAmExVectorArtView : BTUIKCardVectorArtView
 
 @end

--- a/Sources/BraintreeDropIn/Vector Art/BTUIKApplePayMarkVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/BTUIKApplePayMarkVectorArtView.h
@@ -1,5 +1,6 @@
 #import "BTUIKCardVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKApplePayMarkVectorArtView : BTUIKCardVectorArtView
 
 @end

--- a/Sources/BraintreeDropIn/Vector Art/BTUIKCVVBackVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/BTUIKCVVBackVectorArtView.h
@@ -1,5 +1,6 @@
 #import "BTUIKCardVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKCVVBackVectorArtView : BTUIKCardVectorArtView
 
 @end

--- a/Sources/BraintreeDropIn/Vector Art/BTUIKCVVFrontVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/BTUIKCVVFrontVectorArtView.h
@@ -1,5 +1,6 @@
 #import "BTUIKCardVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKCVVFrontVectorArtView : BTUIKCardVectorArtView
 
 @end

--- a/Sources/BraintreeDropIn/Vector Art/BTUIKCardVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/BTUIKCardVectorArtView.h
@@ -1,5 +1,6 @@
 #import "BTUIKVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKCardVectorArtView : BTUIKVectorArtView
 
 @property (nonatomic, strong) UIColor *highlightColor;

--- a/Sources/BraintreeDropIn/Vector Art/BTUIKDinersClubVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/BTUIKDinersClubVectorArtView.h
@@ -1,5 +1,6 @@
 #import "BTUIKCardVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKDinersClubVectorArtView : BTUIKCardVectorArtView
 
 @end

--- a/Sources/BraintreeDropIn/Vector Art/BTUIKDiscoverVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/BTUIKDiscoverVectorArtView.h
@@ -1,5 +1,6 @@
 #import "BTUIKCardVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKDiscoverVectorArtView : BTUIKCardVectorArtView
 
 @end

--- a/Sources/BraintreeDropIn/Vector Art/BTUIKHiperVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/BTUIKHiperVectorArtView.h
@@ -1,5 +1,6 @@
 #import "BTUIKCardVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKHiperVectorArtView : BTUIKCardVectorArtView
 
 @end

--- a/Sources/BraintreeDropIn/Vector Art/BTUIKHipercardVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/BTUIKHipercardVectorArtView.h
@@ -1,5 +1,6 @@
 #import "BTUIKCardVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKHipercardVectorArtView : BTUIKCardVectorArtView
 
 @end

--- a/Sources/BraintreeDropIn/Vector Art/BTUIKJCBVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/BTUIKJCBVectorArtView.h
@@ -1,5 +1,6 @@
 #import "BTUIKCardVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKJCBVectorArtView : BTUIKCardVectorArtView
 
 @end

--- a/Sources/BraintreeDropIn/Vector Art/BTUIKMaestroVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/BTUIKMaestroVectorArtView.h
@@ -1,5 +1,6 @@
 #import "BTUIKCardVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKMaestroVectorArtView : BTUIKCardVectorArtView
 
 @end

--- a/Sources/BraintreeDropIn/Vector Art/BTUIKMasterCardVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/BTUIKMasterCardVectorArtView.h
@@ -1,5 +1,6 @@
 #import "BTUIKCardVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKMasterCardVectorArtView : BTUIKCardVectorArtView
 
 @end

--- a/Sources/BraintreeDropIn/Vector Art/BTUIKPayPalMonogramCardView.h
+++ b/Sources/BraintreeDropIn/Vector Art/BTUIKPayPalMonogramCardView.h
@@ -1,5 +1,6 @@
 #import "BTUIKCardVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKPayPalMonogramCardView : BTUIKCardVectorArtView
 
 @end

--- a/Sources/BraintreeDropIn/Vector Art/BTUIKPayPalWordmarkCompactVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/BTUIKPayPalWordmarkCompactVectorArtView.h
@@ -1,5 +1,6 @@
 #import "BTUIKPayPalWordmarkVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKPayPalWordmarkCompactVectorArtView : BTUIKPayPalWordmarkVectorArtView
 
 @end

--- a/Sources/BraintreeDropIn/Vector Art/BTUIKPayPalWordmarkVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/BTUIKPayPalWordmarkVectorArtView.h
@@ -1,6 +1,7 @@
 #import <UIKit/UIKit.h>
 #import "BTUIKVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKPayPalWordmarkVectorArtView : BTUIKVectorArtView
 
 ///  Initializes a PayPal Wordmark with padding

--- a/Sources/BraintreeDropIn/Vector Art/BTUIKUnionPayVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/BTUIKUnionPayVectorArtView.h
@@ -1,5 +1,6 @@
 #import "BTUIKCardVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKUnionPayVectorArtView : BTUIKCardVectorArtView
 
 @end

--- a/Sources/BraintreeDropIn/Vector Art/BTUIKUnknownCardVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/BTUIKUnknownCardVectorArtView.h
@@ -1,5 +1,6 @@
 #import "BTUIKCardVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKUnknownCardVectorArtView : BTUIKCardVectorArtView
 
 @end

--- a/Sources/BraintreeDropIn/Vector Art/BTUIKVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/BTUIKVectorArtView.h
@@ -1,5 +1,6 @@
 #import <UIKit/UIKit.h>
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 /// Subclassed to easily draw vector art into a scaled UIView.
 /// Useful for using generated UIBezierPath code from
 /// [PaintCode](http://www.paintcodeapp.com/) verbatim.

--- a/Sources/BraintreeDropIn/Vector Art/BTUIKVenmoMonogramCardView.h
+++ b/Sources/BraintreeDropIn/Vector Art/BTUIKVenmoMonogramCardView.h
@@ -1,5 +1,6 @@
 #import "BTUIKCardVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKVenmoMonogramCardView : BTUIKCardVectorArtView
 
 @end

--- a/Sources/BraintreeDropIn/Vector Art/BTUIKVenmoWordmarkVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/BTUIKVenmoWordmarkVectorArtView.h
@@ -1,5 +1,6 @@
 #import "BTUIKVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKVenmoWordmarkVectorArtView : BTUIKVectorArtView
 
 @property (nonatomic, strong) UIColor *color;

--- a/Sources/BraintreeDropIn/Vector Art/BTUIKVisaVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/BTUIKVisaVectorArtView.h
@@ -1,5 +1,6 @@
 #import "BTUIKCardVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKVisaVectorArtView : BTUIKCardVectorArtView
 
 @end

--- a/Sources/BraintreeDropIn/Vector Art/Large/BTUIKLargeApplePayMarkVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/Large/BTUIKLargeApplePayMarkVectorArtView.h
@@ -1,5 +1,6 @@
 #import "BTUIKLargeVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKLargeApplePayMarkVectorArtView : BTUIKLargeVectorArtView
 
 @end

--- a/Sources/BraintreeDropIn/Vector Art/Large/BTUIKLargeDinersClubVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/Large/BTUIKLargeDinersClubVectorArtView.h
@@ -1,5 +1,6 @@
 #import "BTUIKLargeVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKLargeDinersClubVectorArtView : BTUIKLargeVectorArtView
 
 @end

--- a/Sources/BraintreeDropIn/Vector Art/Large/BTUIKLargeDiscoverVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/Large/BTUIKLargeDiscoverVectorArtView.h
@@ -1,5 +1,6 @@
 #import "BTUIKLargeVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKLargeDiscoverVectorArtView : BTUIKLargeVectorArtView
 
 @end

--- a/Sources/BraintreeDropIn/Vector Art/Large/BTUIKLargeHiperVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/Large/BTUIKLargeHiperVectorArtView.h
@@ -1,5 +1,6 @@
 #import "BTUIKLargeVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKLargeHiperVectorArtView : BTUIKLargeVectorArtView
 
 @end

--- a/Sources/BraintreeDropIn/Vector Art/Large/BTUIKLargeHipercardVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/Large/BTUIKLargeHipercardVectorArtView.h
@@ -1,5 +1,6 @@
 #import "BTUIKLargeVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKLargeHipercardVectorArtView : BTUIKLargeVectorArtView
 
 @end

--- a/Sources/BraintreeDropIn/Vector Art/Large/BTUIKLargeJCBVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/Large/BTUIKLargeJCBVectorArtView.h
@@ -1,5 +1,6 @@
 #import "BTUIKLargeVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKLargeJCBVectorArtView : BTUIKLargeVectorArtView
 
 @end

--- a/Sources/BraintreeDropIn/Vector Art/Large/BTUIKLargeMaestroVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/Large/BTUIKLargeMaestroVectorArtView.h
@@ -1,5 +1,6 @@
 #import "BTUIKLargeVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKLargeMaestroVectorArtView : BTUIKLargeVectorArtView
 
 @end

--- a/Sources/BraintreeDropIn/Vector Art/Large/BTUIKLargeMasterCardVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/Large/BTUIKLargeMasterCardVectorArtView.h
@@ -1,5 +1,6 @@
 #import "BTUIKLargeVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKLargeMasterCardVectorArtView : BTUIKLargeVectorArtView
 
 @end

--- a/Sources/BraintreeDropIn/Vector Art/Large/BTUIKLargePayPalMonogramCardView.h
+++ b/Sources/BraintreeDropIn/Vector Art/Large/BTUIKLargePayPalMonogramCardView.h
@@ -1,5 +1,6 @@
 #import "BTUIKLargeVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKLargePayPalMonogramCardView : BTUIKLargeVectorArtView
 
 @end

--- a/Sources/BraintreeDropIn/Vector Art/Large/BTUIKLargeUnionPayVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/Large/BTUIKLargeUnionPayVectorArtView.h
@@ -1,5 +1,6 @@
 #import "BTUIKLargeVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKLargeUnionPayVectorArtView : BTUIKLargeVectorArtView
 
 @end

--- a/Sources/BraintreeDropIn/Vector Art/Large/BTUIKLargeUnknownCardVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/Large/BTUIKLargeUnknownCardVectorArtView.h
@@ -1,5 +1,6 @@
 #import "BTUIKLargeVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKLargeUnknownCardVectorArtView : BTUIKLargeVectorArtView
 
 @end

--- a/Sources/BraintreeDropIn/Vector Art/Large/BTUIKLargeVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/Large/BTUIKLargeVectorArtView.h
@@ -1,5 +1,6 @@
 #import "BTUIKVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKLargeVectorArtView : BTUIKVectorArtView
 
 @end

--- a/Sources/BraintreeDropIn/Vector Art/Large/BTUIKLargeVenmoMonogramCardView.h
+++ b/Sources/BraintreeDropIn/Vector Art/Large/BTUIKLargeVenmoMonogramCardView.h
@@ -1,5 +1,6 @@
 #import "BTUIKLargeVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKLargeVenmoMonogramCardView : BTUIKLargeVectorArtView
 
 @end

--- a/Sources/BraintreeDropIn/Vector Art/Large/BTUIKLargeVisaVectorArtView.h
+++ b/Sources/BraintreeDropIn/Vector Art/Large/BTUIKLargeVisaVectorArtView.h
@@ -1,5 +1,6 @@
 #import "BTUIKLargeVectorArtView.h"
 
+__attribute__((deprecated("BraintreeDropIn is deprecated. Use the Braintre SDK instead. See https://developer.paypal.com/braintree/docs/guides/client-sdk/setup/ for more information.")))
 @interface BTUIKLargeVisaVectorArtView : BTUIKLargeVectorArtView
 
 @end


### PR DESCRIPTION
<img width="923" height="218" alt="Screenshot 2025-07-30 at 2 13 48 PM" src="https://github.com/user-attachments/assets/3bf9cff5-4b4e-4848-a979-04976c9cf24a" />

### Summary of changes

 - Added deprecation tags to all drop-in classes in the header `.h` files 
 - Resolved Package error from `Braintree` to `braintree_ios`

 ### Checklist

 - [ ] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.

- @stechiu 
